### PR TITLE
Fix the use of -mtowncrier. #163

### DIFF
--- a/src/towncrier/__main__.py
+++ b/src/towncrier/__main__.py
@@ -1,4 +1,3 @@
-import towncrier
+from towncrier._shell import cli
 
-
-__name__ == "__main__" and towncrier._main()
+cli()

--- a/src/towncrier/newsfragments/163.bugfix
+++ b/src/towncrier/newsfragments/163.bugfix
@@ -1,0 +1,1 @@
+Invoking towncrier as `python -m towncrier` works.

--- a/src/towncrier/test/test_project.py
+++ b/src/towncrier/test/test_project.py
@@ -43,7 +43,7 @@ class VersionFetchingTests(TestCase):
 class InvocationTests(TestCase):
     def test_dash_m(self):
         """
-        `python -m towncrier` works.
+        `python -m towncrier` invokes the main entrypoint.
         """
         temp = self.mktemp()
         new_dir = os.path.join(temp, "dashm")

--- a/src/towncrier/test/test_project.py
+++ b/src/towncrier/test/test_project.py
@@ -2,6 +2,7 @@
 # See LICENSE for details.
 
 import os
+from subprocess import check_output
 
 from twisted.trial.unittest import TestCase
 
@@ -36,3 +37,24 @@ class VersionFetchingTests(TestCase):
 
         version = get_version(temp, "mytestproja")
         self.assertEqual(version, "1.3.12")
+
+
+class InvocationTests(TestCase):
+    def test_dash_m(self):
+        """
+        `python -m towncrier` works.
+        """
+        temp = self.mktemp()
+        new_dir = os.path.join(temp, "dashm")
+        os.makedirs(new_dir)
+        orig_dir = os.getcwd()
+        try:
+            os.chdir(new_dir)
+            with open("pyproject.toml", "w") as f:
+                f.write('[tool.towncrier]\n' 'directory = "news"\n')
+            os.makedirs("news")
+            out = check_output(["python", "-m", "towncrier", "--help"])
+            self.assertIn(b"[OPTIONS] COMMAND [ARGS]...", out)
+            self.assertIn(b"--help  Show this message and exit.", out)
+        finally:
+            os.chdir(orig_dir)

--- a/src/towncrier/test/test_project.py
+++ b/src/towncrier/test/test_project.py
@@ -2,6 +2,7 @@
 # See LICENSE for details.
 
 import os
+import sys
 from subprocess import check_output
 
 from twisted.trial.unittest import TestCase
@@ -53,7 +54,7 @@ class InvocationTests(TestCase):
             with open("pyproject.toml", "w") as f:
                 f.write('[tool.towncrier]\n' 'directory = "news"\n')
             os.makedirs("news")
-            out = check_output(["python", "-m", "towncrier", "--help"])
+            out = check_output([sys.executable, "-m", "towncrier", "--help"])
             self.assertIn(b"[OPTIONS] COMMAND [ARGS]...", out)
             self.assertIn(b"--help  Show this message and exit.", out)
         finally:


### PR DESCRIPTION
This makes the -m invocation work.

I added a test, but:
- I didn't know in what file you wanted it
- I didn't know if Trial had a way to manage the current directory

Let me know if I should change anything.