### PR TITLE
Improve news fragment file name parsing

### DIFF
--- a/src/towncrier/newsfragments/173.feature.rst
+++ b/src/towncrier/newsfragments/173.feature.rst
@@ -1,0 +1,3 @@
+ Improve news fragment file name parsing to allow using file names like
+ ``123.feature.1.ext`` which are convenient when one wants to use an appropriate
+ extension (e.g. ``rst``, ``md``) to enable syntax highlighting.

--- a/src/towncrier/test/test_builder.py
+++ b/src/towncrier/test/test_builder.py
@@ -13,9 +13,21 @@ class TestParseNewsfragmentBasename(TestCase):
             ("123", "feature", 0),
         )
 
+    def test_invalid_category(self):
+        self.assertEqual(
+            parse_newfragment_basename("README.ext", ["feature"]),
+            (None, None, None),
+        )
+
     def test_counter(self):
         self.assertEqual(
             parse_newfragment_basename("123.feature.1", ["feature"]),
+            ("123", "feature", 1),
+        )
+
+    def test_counter_with_extension(self):
+        self.assertEqual(
+            parse_newfragment_basename("123.feature.1.ext", ["feature"]),
             ("123", "feature", 1),
         )
 
@@ -31,15 +43,22 @@ class TestParseNewsfragmentBasename(TestCase):
             ("baz", "feature", 0),
         )
 
+    def test_non_numeric_ticket_with_extension(self):
+        self.assertEqual(
+            parse_newfragment_basename("baz.feature.ext", ["feature"]),
+            ("baz", "feature", 0),
+        )
+
     def test_dots_in_ticket_name(self):
         self.assertEqual(
             parse_newfragment_basename("baz.1.2.feature", ["feature"]),
             ("2", "feature", 0),
         )
 
-    def test_dots_in_ticket_name_unknown_category(self):
+    def test_dots_in_ticket_name_invalid_category(self):
         self.assertEqual(
-            parse_newfragment_basename("baz.1.2.notfeature", ["feature"]), ("1", "2", 0)
+            parse_newfragment_basename("baz.1.2.notfeature", ["feature"]),
+            (None, None, None),
         )
 
     def test_dots_in_ticket_name_and_counter(self):


### PR DESCRIPTION
The new version uses category as the reference point to later infer the issue number and counter value.
As a consequence, it will return `(None, None, None)` if the base name doesn't contain a valid category.

The new parser allows using file names like `123.feature.1.ext` which are convenient when one wants to use an appropriate extension (e.g. `rst`, `md`) to enable syntax highlighting.