### PR TITLE
Make check subcommand detect if only configured news file has changed

### DIFF
--- a/src/towncrier/check.py
+++ b/src/towncrier/check.py
@@ -34,7 +34,15 @@ def __main(comparewith, directory, config):
     try:
         files_changed = (
             _run(
-                ["git", "diff", "--name-only", comparewith + "..."], cwd=base_directory
+                ["git",
+                 "diff",
+                 "--name-only",
+                 # Only show files that were Added (A), Copied (C), Modified (M)
+                 # or Renamed (R).
+                 "--diff-filter=ACMR",
+                 comparewith + "..."
+                ],
+                cwd=base_directory
             )
             .decode(getattr(sys.stdout, "encoding", "utf8"))
             .strip()
@@ -48,10 +56,14 @@ def __main(comparewith, directory, config):
         click.echo("On trunk, or no diffs, so no newsfragment required.")
         sys.exit(0)
 
+    if files_changed == config["filename"]:
+        click.echo("Only the configured news file has changed.")
+        sys.exit(0)
+
     files = set(
         map(
             lambda x: os.path.join(base_directory, x),
-            files_changed.strip().split(os.linesep),
+            files_changed.split(os.linesep),
         )
     )
 

--- a/src/towncrier/newsfragments/174.feature.rst
+++ b/src/towncrier/newsfragments/174.feature.rst
@@ -1,0 +1,6 @@
+Make the ``check`` subcommand detect if only the configured news file has
+changed.
+
+This should enable the ``check`` subcommand to be used as a CI lint step and
+not fail when a pull request only modifies the configured news file (i.e. when
+the news file is being assembled for the next release).


### PR DESCRIPTION
This should enable the `check` subcommand to be used as a CI lint step and not fail when a pull request only modifies the configured news file (i.e. when the news file is being assembled for the next release).

Closes #152.