### PR TITLE
One check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,23 +50,16 @@ jobs:
   check:
     name: Check - ${{ matrix.python.name }}
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python:
-          - name: CPython 3.6
-            tox: py36
-            action: 3.6
 
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
-    - name: Set up ${{ matrix.python.name }}
+    - name: Set up CPython 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python.action }}
+        python-version: 3.6
 
     - uses: twisted/python-info-action@v1.0.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.task.name}} - ${{ matrix.python.name }}
+    name: Test - ${{ matrix.python.name }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -26,9 +26,6 @@ jobs:
           - name: CPython 3.7
             tox: py37
             action: 3.7
-        task:
-          - name: Test
-            tox: tests
 
     steps:
     - uses: actions/checkout@v2
@@ -48,10 +45,10 @@ jobs:
 
     - name: Codecov
       run: |
-        codecov -n "GitHub Actions - ${{ matrix.task.name}} - ${{ matrix.python.name }}"
+        codecov -n "GitHub Actions - Test - ${{ matrix.python.name }}"
 
   check:
-    name: ${{ matrix.task.name}} - ${{ matrix.python.name }}
+    name: Check - ${{ matrix.python.name }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -60,13 +57,6 @@ jobs:
           - name: CPython 3.6
             tox: py36
             action: 3.6
-        task:
-          - name: Flake8
-            tox: flake8
-          - name: Check Manifest
-            tox: check-manifest
-          - name: Check Newsfragment
-            tox: check-newsfragment
 
     steps:
     - uses: actions/checkout@v2
@@ -83,8 +73,14 @@ jobs:
     - name: Install dependencies
       run: python -m pip install --upgrade pip tox
 
-    - name: Check
-      run: tox -c tox.ini -e ${{ matrix.task.tox }}
+    - name: Lint
+      run: tox -c tox.ini -e flake8
+
+    - name: Manifest
+      run: tox -c tox.ini -e check-manifest
+
+    - name: Newsfragment
+      run: tox -c tox.ini -e check-newsfragment
 
   all:
     name: All

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,18 +82,19 @@ jobs:
     - uses: twisted/python-info-action@v1.0.1
 
     - name: Install dependencies
+      id: last_step_before_checks
       run: python -m pip install --upgrade pip tox
 
     - name: Lint
-      if: always()
+      if: ${{ steps.last_step_before_checks.conclusion }} == "success"
       run: tox -c tox.ini -e flake8
 
     - name: Manifest
-      if: always()
+      if: ${{ steps.last_step_before_checks.conclusion }} == "success"
       run: tox -c tox.ini -e check-manifest
 
     - name: Newsfragment
-      if: always()
+      if: ${{ steps.last_step_before_checks.conclusion }} == "success"
       run: tox -c tox.ini -e check-newsfragment
 
   all:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,15 +86,15 @@ jobs:
       run: python -m pip install --upgrade pip tox
 
     - name: Lint
-      if: ${{ steps.last_step_before_checks.conclusion }} == "success"
+      if: ${{ steps.last_step_before_checks.outcome }} == "success"
       run: tox -c tox.ini -e flake8
 
     - name: Manifest
-      if: ${{ steps.last_step_before_checks.conclusion }} == "success"
+      if: ${{ steps.last_step_before_checks.outcome }} == "success"
       run: tox -c tox.ini -e check-manifest
 
     - name: Newsfragment
-      if: ${{ steps.last_step_before_checks.conclusion }} == "success"
+      if: ${{ steps.last_step_before_checks.outcome }} == "success"
       run: tox -c tox.ini -e check-newsfragment
 
   all:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,12 +85,15 @@ jobs:
       run: python -m pip install --upgrade pip tox
 
     - name: Lint
+      if: always()
       run: tox -c tox.ini -e flake8
 
     - name: Manifest
+      if: always()
       run: tox -c tox.ini -e check-manifest
 
     - name: Newsfragment
+      if: always()
       run: tox -c tox.ini -e check-newsfragment
 
   all:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,15 +96,15 @@ jobs:
       run: python -m pip install --upgrade pip tox
 
     - name: Lint
-      if: ${{ steps.last_step_before_checks.outcome }} == "success"
+      if: always()
       run: tox -c tox.ini -e flake8
 
     - name: Manifest
-      if: ${{ steps.last_step_before_checks.outcome }} == "success"
+      if: always()
       run: tox -c tox.ini -e check-manifest
 
     - name: Newsfragment
-      if: ${{ steps.last_step_before_checks.outcome }} == "success"
+      if: always()
       run: tox -c tox.ini -e check-newsfragment
 
   all:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,6 @@ jobs:
           - name: PyPy 3
             tox: pypy3
             action: pypy3
-        task:
-          - name: Test
-            tox: tests
 
     steps:
     - uses: actions/checkout@v2
@@ -68,7 +65,7 @@ jobs:
         codecov -n "GitHub Actions - Test - ${{ matrix.os.name }} ${{ matrix.python.name }}"
 
   check:
-    name: Check - ${{ matrix.python.name }}
+    name: Check
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up CPython 3.6
-      uses: actions/setup-python@v2
+    - uses: actions/setup-python@v2
       with:
         python-version: 3.6
 

--- a/src/towncrier/__init__.py
+++ b/src/towncrier/__init__.py
@@ -8,3 +8,5 @@ towncrier, a builder for your news files.
 from ._version import __version__
 
 __all__ = ["__version__"]
+
+let_us_fail_lint = ["this", "that", "more", "and", "always", "but", "this", "is", "a", "silly", "way", "but", "it", "should", "work"]

--- a/src/towncrier/__init__.py
+++ b/src/towncrier/__init__.py
@@ -8,5 +8,3 @@ towncrier, a builder for your news files.
 from ._version import __version__
 
 __all__ = ["__version__"]
-
-let_us_fail_lint = ["this", "that", "more", "and", "always", "but", "this", "is", "a", "silly", "way", "but", "it", "should", "work"]


### PR DESCRIPTION
Draft for:
- [x] Revisit after #291 and #287 expand the CI matrix coverage
- [x] Adjust so that all check outputs are present but any single one will result in failure
  - Using `if: always()` like this makes all three run even when a previous step has failed.  This isn't great but I don't have a better working solution and running a few extra steps that will likely fail as well when there's an oddball failure in setup steps doesn't seem super problematic.
  - Here's an example failing build.
    - https://github.com/twisted/towncrier/pull/292/checks?check_run_id=1508471988
    - ![image](https://user-images.githubusercontent.com/543719/101309018-46514080-3819-11eb-96bb-a9fb81244fa6.png)
