### PR TITLE
less leading spaces in 173.feature.rst

### DIFF
--- a/src/towncrier/newsfragments/173.feature.rst
+++ b/src/towncrier/newsfragments/173.feature.rst
@@ -1,3 +1,3 @@
- Improve news fragment file name parsing to allow using file names like
- ``123.feature.1.ext`` which are convenient when one wants to use an appropriate
- extension (e.g. ``rst``, ``md``) to enable syntax highlighting.
+Improve news fragment file name parsing to allow using file names like
+``123.feature.1.ext`` which are convenient when one wants to use an appropriate
+extension (e.g. ``rst``, ``md``) to enable syntax highlighting.


### PR DESCRIPTION
This resulted in an extra space of indent on the hanging lines which caused misformatting when rendered.