### PR TITLE
Prepare for tox v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,30 +24,39 @@ jobs:
           - name: CPython 2.7
             tox: py27
             action: 2.7
+            tox_command: tox
           - name: CPython 3.5
             tox: py35
             action: 3.5
+            tox_command: tox
           - name: CPython 3.6
             tox: py36
             action: 3.6
+            tox_command: tox4
           - name: CPython 3.7
             tox: py37
             action: 3.7
+            tox_command: tox4
           - name: CPython 3.8
             tox: py38
             action: 3.8
+            tox_command: tox4
           - name: CPython 3.9
             tox: py39
             action: 3.9
+            tox_command: tox4
           - name: PyPy 2.7
             tox: pypy27
             action: pypy-2.7
+            tox_command: tox
           - name: PyPy 3.6
             tox: pypy36
             action: pypy-3.6
+            tox_command: tox4
           - name: PyPy 3.7
             tox: pypy37
             action: pypy-3.7
+            tox_command: tox4
         task:
           - name: Test
             tox: tests
@@ -76,7 +85,7 @@ jobs:
         python -m pip install --upgrade --pre tox
 
     - name: Test
-      run: tox4 -c tox.ini -e ${{ matrix.python.tox }}-tests
+      run: ${{ matrix.python.tox_command }} -c tox.ini -e ${{ matrix.python.tox }}-tests
 
     - name: Codecov
       run: |
@@ -120,7 +129,7 @@ jobs:
         python -m pip install --upgrade --pre tox
 
     - name: Check
-      run: tox4 -c tox.ini -e ${{ matrix.task.tox }}
+      run: ${{ matrix.python.tox_command }} -c tox.ini -e ${{ matrix.task.tox }}
 
   all:
     name: All

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,7 @@ jobs:
     - uses: twisted/python-info-action@v1.0.1
 
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip codecov
-        python -m pip install --upgrade --pre tox
+      run: python -m pip install --upgrade pip tox codecov
 
     - name: Test
       run: ${{ matrix.python.tox_command }} -c tox.ini -e ${{ matrix.python.tox }}-tests
@@ -125,9 +123,7 @@ jobs:
     - uses: twisted/python-info-action@v1.0.1
 
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip codecov
-        python -m pip install --upgrade --pre tox
+      run: python -m pip install --upgrade pip tox
 
     - name: Check
       run: ${{ matrix.python.tox_command }} -c tox.ini -e ${{ matrix.task.tox }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           - name: PyPy 2.7
             tox: pypy27
             action: pypy-2.7
-            tox_major: 4
+            tox_major: 3
           - name: PyPy 3.6
             tox: pypy36
             action: pypy-3.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,39 +24,49 @@ jobs:
           - name: CPython 2.7
             tox: py27
             action: 2.7
-            tox_command: tox
+            tox_major: 3
           - name: CPython 3.5
             tox: py35
             action: 3.5
-            tox_command: tox
+            tox_major: 3
           - name: CPython 3.6
             tox: py36
             action: 3.6
-            tox_command: tox4
+            tox_major: 4
           - name: CPython 3.7
             tox: py37
             action: 3.7
-            tox_command: tox4
+            tox_major: 4
           - name: CPython 3.8
             tox: py38
             action: 3.8
-            tox_command: tox4
+            tox_major: 4
           - name: CPython 3.9
             tox: py39
             action: 3.9
-            tox_command: tox4
+            tox_major: 4
           - name: PyPy 2.7
             tox: pypy27
             action: pypy-2.7
-            tox_command: tox
+            tox_major: 4
           - name: PyPy 3.6
             tox: pypy36
             action: pypy-3.6
-            tox_command: tox4
+            tox_major: 4
           - name: PyPy 3.7
             tox: pypy37
             action: pypy-3.7
-            tox_command: tox4
+            tox_major: 4
+        tox:
+          # There is only a single value here so the matrix size is not
+          # increased.  This does give a nice way to define variables
+          # though.
+          - 3:
+              command: tox
+              version_specifier: tox~=3.0
+            4:
+              command: tox4
+              version_specifier: tox~=4.0a5
         task:
           - name: Test
             tox: tests
@@ -80,10 +90,10 @@ jobs:
     - uses: twisted/python-info-action@v1.0.1
 
     - name: Install dependencies
-      run: python -m pip install --upgrade pip tox codecov
+      run: python -m pip install --upgrade pip codecov ${{ matrix.tox[matrix.python.tox.major].version_specifier }}
 
     - name: Test
-      run: ${{ matrix.python.tox_command }} -c tox.ini -e ${{ matrix.python.tox }}-tests
+      run: ${{ matrix.tox[matrix.python.tox_major].command }} -c tox.ini -e ${{ matrix.python.tox }}-tests
 
     - name: Codecov
       run: |
@@ -101,7 +111,17 @@ jobs:
           - name: CPython 3.8
             tox: py38
             action: 3.8
-            tox_command: tox4
+            tox_major: 4
+        tox:
+          # There is only a single value here so the matrix size is not
+          # increased.  This does give a nice way to define variables
+          # though.
+          - 3:
+              command: tox
+              version_specifier: tox~=3.0
+            4:
+              command: tox4
+              version_specifier: tox~=4.0a5
         task:
           - name: Flake8
             tox: flake8
@@ -123,10 +143,10 @@ jobs:
     - uses: twisted/python-info-action@v1.0.1
 
     - name: Install dependencies
-      run: python -m pip install --upgrade pip tox
+      run: python -m pip install --upgrade pip ${{ matrix.tox[matrix.python.tox.major].version_specifier }}
 
     - name: Check
-      run: ${{ matrix.python.tox_command }} -c tox.ini -e ${{ matrix.task.tox }}
+      run: ${{ matrix.tox[matrix.python.tox_major].command }} -c tox.ini -e ${{ matrix.task.tox }}
 
   all:
     name: All

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,9 @@ jobs:
     - uses: twisted/python-info-action@v1.0.1
 
     - name: Install dependencies
-      run: python -m pip install --upgrade pip tox codecov
+      run: |
+        python -m pip install --upgrade pip codecov
+        python -m pip install --upgrade --pre tox
 
     - name: Test
       run: tox -c tox.ini -e ${{ matrix.python.tox }}-tests
@@ -113,7 +115,9 @@ jobs:
     - uses: twisted/python-info-action@v1.0.1
 
     - name: Install dependencies
-      run: python -m pip install --upgrade pip tox
+      run: |
+        python -m pip install --upgrade pip codecov
+        python -m pip install --upgrade --pre tox
 
     - name: Check
       run: tox -c tox.ini -e ${{ matrix.task.tox }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
     - uses: twisted/python-info-action@v1.0.1
 
     - name: Install dependencies
-      run: python -m pip install --upgrade pip codecov ${{ matrix.tox[matrix.python.tox.major].version_specifier }}
+      run: python -m pip install --upgrade pip codecov ${{ matrix.tox[matrix.python.tox_major].version_specifier }}
 
     - name: Test
       run: ${{ matrix.tox[matrix.python.tox_major].command }} -c tox.ini -e ${{ matrix.python.tox }}-tests
@@ -143,7 +143,7 @@ jobs:
     - uses: twisted/python-info-action@v1.0.1
 
     - name: Install dependencies
-      run: python -m pip install --upgrade pip ${{ matrix.tox[matrix.python.tox.major].version_specifier }}
+      run: python -m pip install --upgrade pip ${{ matrix.tox[matrix.python.tox_major].version_specifier }}
 
     - name: Check
       run: ${{ matrix.tox[matrix.python.tox_major].command }} -c tox.ini -e ${{ matrix.task.tox }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         python -m pip install --upgrade --pre tox
 
     - name: Test
-      run: tox -c tox.ini -e ${{ matrix.python.tox }}-tests
+      run: tox4 -c tox.ini -e ${{ matrix.python.tox }}-tests
 
     - name: Codecov
       run: |
@@ -120,7 +120,7 @@ jobs:
         python -m pip install --upgrade --pre tox
 
     - name: Check
-      run: tox -c tox.ini -e ${{ matrix.task.tox }}
+      run: tox4 -c tox.ini -e ${{ matrix.task.tox }}
 
   all:
     name: All

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
           - name: CPython 3.8
             tox: py38
             action: 3.8
+            tox_command: tox4
         task:
           - name: Flake8
             tox: flake8


### PR DESCRIPTION
Alphas are being pre-released so may as well try them out somewhere.

Draft for:
- [ ] This is never to be merged.  Rather, it is for testing the prereleases with the `tox4` command.  On release the command will return to just `tox`.
- [ ] ~~tox 4 being released~~
- [ ] ~~Removing the `--pre` for tox now that we know it (at least the alpha 5) works~~
  - Just specified 4 specifically (allowing alpha5+)