### PR TITLE
Provide a --version option

### DIFF
--- a/src/towncrier/_shell.py
+++ b/src/towncrier/_shell.py
@@ -11,9 +11,11 @@ from click_default_group import DefaultGroup
 from .build import _main as _build_cmd
 from .check import _main as _check_cmd
 from .create import _main as _create_cmd
+from ._version import __version__
 
 
 @click.group(cls=DefaultGroup, default="build", default_if_no_args=True)
+@click.version_option(__version__.public())
 def cli():
     pass
 

--- a/src/towncrier/newsfragments/339.feature.rst
+++ b/src/towncrier/newsfragments/339.feature.rst
@@ -1,0 +1,1 @@
+towncrier --version` was added to the command line interface to show the product version.

--- a/src/towncrier/test/test_project.py
+++ b/src/towncrier/test/test_project.py
@@ -116,6 +116,13 @@ class InvocationTests(TestCase):
             os.makedirs("news")
             out = check_output([sys.executable, "-m", "towncrier", "--help"])
             self.assertIn(b"[OPTIONS] COMMAND [ARGS]...", out)
-            self.assertIn(b"--help  Show this message and exit.", out)
+            self.assertRegex(out, br".*--help\s+Show this message and exit.")
         finally:
             os.chdir(orig_dir)
+
+    def test_version(self):
+        """
+        `--version` command line option is available to show the current production version.
+        """
+        out = check_output(["towncrier", "--version"])
+        self.assertTrue(out.startswith(b"towncrier, version 2"))


### PR DESCRIPTION
This PR fixes #339 and adds a `--version` option. This makes it possible to run the command like this:

```
$ towncrier --version
towncrier, version 21.3.1.dev0
```