### PR TITLE
Stop writing title twice when title_format is specified

### DIFF
--- a/src/towncrier/_writer.py
+++ b/src/towncrier/_writer.py
@@ -38,7 +38,6 @@ def append_to_newsfile(
             if start_string:
                 f.write((u"\n\n" + start_string + u"\n").encode("utf8"))
 
-        f.write(top_line.encode("utf8"))
         f.write(content.encode("utf8"))
         if existing_content:
             if existing_content[0]:

--- a/src/towncrier/newsfragments/346.bugfix
+++ b/src/towncrier/newsfragments/346.bugfix
@@ -1,0 +1,1 @@
+Stop writing title twice when ``title_format`` is specified.


### PR DESCRIPTION
Closes #346

The title is already rendered in `content`. This does not fix draft mode, but that is recorded in a separate issue.