### PR TITLE
Handle deletion of uncommitted news fragments

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -28,8 +28,9 @@ If there are no news fragments (including an empty fragments directory or a
 non-existent directory), a notice of "no significant changes" will be added to
 the news file.
 
-By default, the processed news fragments are removed using ``git``, which will
-also remove the fragments directory if now empty.
+By default, the processed news fragments are removed. For any fragments
+committed in your git repository, git rm will be used (which will also remove
+the fragments directory if now empty).
 
 .. option:: --draft
 

--- a/src/towncrier/newsfragments/357.feature.rst
+++ b/src/towncrier/newsfragments/357.feature.rst
@@ -1,0 +1,1 @@
+``towncrier build`` now handles removing news fragments which are not part of the git repository. For example, uncommitted or unstaged files.


### PR DESCRIPTION
Before this commit, all the news fragments needed to be committed into git, or the fragments removal after building the news file would crash.

In my workflow, I add missing fragments before building the news file because I'm extracting author names from the git log, and towncrier crashes at the end of the build process.