### PR TITLE
feat(settings): Add support to tables in toml settings

### DIFF
--- a/src/towncrier/_settings.py
+++ b/src/towncrier/_settings.py
@@ -101,8 +101,17 @@ def parse_toml(base_path, config):
         sections[""] = ""
 
     if "type" in config:
-        for x in config["type"]:
-            types[x["directory"]] = {"name": x["name"], "showcontent": x["showcontent"]}
+        type_config = config["type"]
+        if hasattr(type_config, "values"):
+            type_config = type_config.values()
+        for type_config in type_config:
+            directory = type_config["directory"]
+            fragment_type_name = type_config["name"]
+            is_content_required = type_config["showcontent"]
+            types[directory] = {
+                "name": fragment_type_name,
+                "showcontent": is_content_required,
+            }
     else:
         types = _default_types
 

--- a/src/towncrier/newsfragments/361.feature.rst
+++ b/src/towncrier/newsfragments/361.feature.rst
@@ -1,0 +1,1 @@
+Added support to tables in toml settings.

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -199,3 +199,83 @@ package = "foobar"
         self.assertEqual(
             str(e.exception), "Towncrier does not have a template named 'foo'."
         )
+
+    def test_custom_types_as_tables_array(self):
+        """
+        Custom fragment categories can be defined inside
+        the toml config file using an array of tables
+        (a table name in double brackets).
+        """
+        toml_content = (
+            "[tool.towncrier]\n"
+            "package = \"foobar\"\n"
+            "[[tool.towncrier.type]]\n"
+            "directory=\"foo\"\n"
+            "name=\"Foo\"\n"
+            "showcontent=true\n"
+            "[[tool.towncrier.type]]\n"
+            "directory=\"spam\"\n"
+            "name=\"Spam\"\n"
+            "showcontent=true\n"
+        )
+        expected = {
+            "foo": {
+                "name": "Foo",
+                "showcontent": True,
+            },
+            "spam": {
+                "name": "Spam",
+                "showcontent": True,
+            },
+        }
+
+        config = self._get_actual_config(
+            toml_content,
+        )
+        actual = config["types"]
+        self.assertDictEqual(expected, actual)
+
+    def test_custom_types_as_tables(self):
+        """
+        Custom fragment categories can be defined inside
+        the toml config file using tables.
+        """
+        test_project_path = self.mktemp()
+        os.makedirs(test_project_path)
+        toml_content = (
+            "[tool.towncrier]\n"
+            "package = \"foobar\"\n"
+            "[tool.towncrier.type.foo]\n"
+            "directory=\"bar\"\n"
+            "name=\"Bazz\"\n"
+            "showcontent=true\n"
+            "[tool.towncrier.type.spam]\n"
+            "directory=\"spam\"\n"
+            "name=\"Spam\"\n"
+            "showcontent=true\n"
+        )
+        expected = {
+            "bar": {
+                "name": "Bazz",
+                "showcontent": True,
+            },
+            "spam": {
+                "name": "Spam",
+                "showcontent": True,
+            },
+        }
+
+        config = self._get_actual_config(
+            toml_content,
+        )
+        actual = config["types"]
+        self.assertDictEqual(expected, actual)
+
+    def _get_actual_config(self, toml_content: str):
+        test_project_path = self.mktemp()
+        os.makedirs(test_project_path)
+        toml_path = os.path.join(test_project_path, "pyproject.toml")
+        with open(toml_path, "w") as f:
+            f.write(toml_content)
+        config = load_config(test_project_path)
+        return config


### PR DESCRIPTION
~~Correct loop so that it iterates over the values and not the keys of the custom fragment types if provided.~~ 

~~Resolves #361~~

* Iterate through values if types is a mapping instead of an array.

Resolves: twisted/#361