### PR TITLE
feat(settings): Add support to configure fragment types via tables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,15 +156,21 @@ If ``title_format`` is unspecified or an empty string, the default format will b
 If set to ``false``, no title will be created.
 This can be useful if the specified template creates the title itself.
 
-Furthermore, you can add your own fragment types using:
+Furthermore, you can customize each of your own fragment types using:
 
 .. code-block:: toml
 
     [tool.towncrier]
-    [[tool.towncrier.type]]
-    directory = "deprecation"
-    name = "Deprecations"
-    showcontent = true
+	# To add custom fragment types, with default setting, just add an empty section.
+    [tool.towncrier.feat]
+    [tool.towncrier.fix]
+
+	# Custom fragment types can have custom attributes
+	# that are used when rendering the result based on the template.
+    [tool.towncrier.chore]
+        name = "Other Tasks"
+        showcontent = false
+
 
 
 Automatic pull request checks

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -25,18 +25,59 @@ Top level keys
 - ``issue_format`` -- A format string for rendering the issue/ticket number in newsfiles. ``#{issue}`` by default.
 - ``underlines`` -- The characters used for underlining headers. ``["=", "-", "~"]`` by default.
 
-
 Custom fragment types
 ---------------------
+``Towncrier`` allows defining custom fragment types. Custom fragment types
+will be used instead ``towncrier`` default ones, they are not combined.
 
-Custom fragment types can be including in the
-pyproject.toml.
-Each custom type (``[[tool.towncrier.type]]``) has the following keys:
+Users can configure each of their own custom fragment types by adding tables to
+the pyproject.toml named ``[tool.towncrier.type.<a custom fragment type>]``.
+
+These tables may include the following optional keys:
+
+ * ``name``: The description of the fragment type, as it must be included
+   in the news file. If omitted, it defaults to  its  fragment type,
+   but capitalized.
+ * ``showcontent``: Whether if the fragment contents should be included in the
+   news file. If omitted, it defaults to ``true``
+
+
+
+For example, if you want your custom fragment types to be
+``["feat", "fix", "chore",]`` and you want all
+of them to use the default configuration except ``"chore"`` you can do it as
+follows:
+
+
+.. code-block:: toml
+
+
+    [tool.towncrier]
+
+
+    [tool.towncrier.fragment.feat]
+    [tool.towncrier.fragment.fix]
+
+    [tool.towncrier.fragment.chore]
+        name = "Other Tasks"
+        showcontent = false
+
+DEPRECATED: Defining custom fragment types with an array of toml tables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Users can create their own custom fragment types by adding an array of
+tables to the pyproject.toml named ``[[tool.towncrier.type]]``.
+
+If still using this way to configure custom fragment types,
+please notice that ``fragment_types`` must be empty or not provided.
+
+Each custom type (``[[tool.towncrier.type]]``) has the following
+mandatory keys:
  * ``directory``: The type of the fragment.
  * ``name``: The description of the fragment type, as it must be included
    in the news file.
  * ``showcontent``: Whether if the fragment contents should be included in the
    news file.
+
 
 
 For example:
@@ -48,3 +89,8 @@ For example:
     directory = "deprecation"
     name = "Deprecations"
     showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "chore"
+    name = "Other Tasks"
+    showcontent = false

--- a/src/towncrier/_settings/__init__.py
+++ b/src/towncrier/_settings/__init__.py
@@ -1,0 +1,14 @@
+"""Subpackage to handle settings parsing."""
+
+from towncrier._settings import load
+
+load_config = load.load_config
+ConfigError = load.ConfigError
+load_config_from_options = load.load_config_from_options
+
+
+__all__ = [
+    "load_config",
+    "ConfigError",
+    "load_config_from_options",
+]

--- a/src/towncrier/_settings/fragment_types.py
+++ b/src/towncrier/_settings/fragment_types.py
@@ -1,0 +1,133 @@
+import abc
+import collections as clt
+
+
+class BaseFragmentTypesLoader:
+    """Base class to load fragment types."""
+
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, config):
+        """Initialize."""
+        self.config = config
+
+    @classmethod
+    def factory(cls, config):
+        fragment_types_class = DefaultFragmentTypesLoader
+        fragment_types = config.get("fragment", {})
+        types_config = config.get("type", {})
+        if fragment_types:
+            fragment_types_class = TableFragmentTypesLoader
+        elif types_config:
+            fragment_types_class = ArrayFragmentTypesLoader
+
+        new = fragment_types_class(config)
+        return new
+
+    @abc.abstractmethod
+    def load(self,):
+        """Load fragment types."""
+
+
+class DefaultFragmentTypesLoader(BaseFragmentTypesLoader):
+    """Default towncrier's fragment types."""
+
+    _default_types = clt.OrderedDict(
+        [
+            (u"feature", {"name": u"Features", "showcontent": True}),
+            (u"bugfix", {"name": u"Bugfixes", "showcontent": True}),
+            (u"doc", {"name": u"Improved Documentation", "showcontent": True}),
+            (u"removal", {"name": u"Deprecations and Removals", "showcontent": True}),
+            (u"misc", {"name": u"Misc", "showcontent": False}),
+        ]
+    )
+
+    def load(self,):
+        """Load default types."""
+        return self._default_types
+
+
+class ArrayFragmentTypesLoader(BaseFragmentTypesLoader):
+    """Load fragment types from an toml array of tables.
+
+    This loader get the custom fragment types defined through a
+    toml array of tables, that ``toml`` parses as an array
+    of mappings.
+
+    For example::
+
+        [tool.towncrier]
+        [[tool.towncrier.type]]
+        directory = "deprecation"
+        name = "Deprecations"
+        showcontent = true
+
+    """
+
+    def load(self,):
+        """Load types from toml array of mappings."""
+
+        types = clt.OrderedDict()
+        types_config = self.config["type"]
+        for type_config in types_config:
+            directory = type_config["directory"]
+            fragment_type_name = type_config["name"]
+            is_content_required = type_config["showcontent"]
+            types[directory] = {
+                "name": fragment_type_name,
+                "showcontent": is_content_required,
+            }
+        return types
+
+
+class TableFragmentTypesLoader(BaseFragmentTypesLoader):
+    """Load fragment types from toml tables.
+
+    This loader get the custom fragment types defined through a
+    toml  tables, that ``toml`` parses as an nested mapping.
+
+    This loader allows omitting ``name`` and
+    ```showcontent`` fields.
+    ``name`` by default is the capitalized
+    fragment type.
+    ``showcontent`` is true by default.
+
+    For example::
+
+        [tool.towncrier]
+        [tool.towncrier.fragment.chore]
+        name = "Chores"
+        showcontent = False
+
+        [tool.towncrier.fragment.deprecations]
+        # name will be "Deprecations"
+        # The content will be shown.
+
+    """
+    def __init__(self, config):
+        """Initialize."""
+        self.config = config
+        self.fragment_options = config.get("fragment", {})
+
+    def load(self,):
+        """Load types from nested mapping."""
+        fragment_types = self.fragment_options.keys()
+        fragment_types = sorted(fragment_types)
+        custom_types_sequence = [
+            (fragment_type, self._load_options(fragment_type))
+            for fragment_type in fragment_types
+        ]
+        types = clt.OrderedDict(custom_types_sequence)
+        return types
+
+    def _load_options(self, fragment_type):
+        """Load fragment options."""
+        capitalized_fragment_type = fragment_type.capitalize()
+        options = self.fragment_options.get(fragment_type, {})
+        fragment_description = options.get("name", capitalized_fragment_type)
+        show_content = options.get("showcontent", True)
+        clean_fragment_options = {
+            "name": fragment_description,
+            "showcontent": show_content,
+        }
+        return clean_fragment_options

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -13,6 +13,7 @@ else:
     import toml
 
 from collections import OrderedDict
+from .._settings import fragment_types as ft
 
 
 class ConfigError(Exception):
@@ -24,15 +25,6 @@ class ConfigError(Exception):
 _start_string = u".. towncrier release notes start\n"
 _title_format = None
 _template_fname = "towncrier:default"
-_default_types = OrderedDict(
-    [
-        (u"feature", {"name": u"Features", "showcontent": True}),
-        (u"bugfix", {"name": u"Bugfixes", "showcontent": True}),
-        (u"doc", {"name": u"Improved Documentation", "showcontent": True}),
-        (u"removal", {"name": u"Deprecations and Removals", "showcontent": True}),
-        (u"misc", {"name": u"Misc", "showcontent": False}),
-    ]
-)
 _underlines = ["=", "-", "~"]
 
 
@@ -92,19 +84,15 @@ def parse_toml(base_path, config):
     config = config["tool"]["towncrier"]
 
     sections = OrderedDict()
-    types = OrderedDict()
-
     if "section" in config:
         for x in config["section"]:
             sections[x.get("name", "")] = x["path"]
     else:
         sections[""] = ""
-
-    if "type" in config:
-        for x in config["type"]:
-            types[x["directory"]] = {"name": x["name"], "showcontent": x["showcontent"]}
-    else:
-        types = _default_types
+    fragment_types_loader = ft.BaseFragmentTypesLoader.factory(
+        config
+    )
+    types = fragment_types_loader.load()
 
     wrap = config.get("wrap", False)
 

--- a/src/towncrier/newsfragments/369.feature.rst
+++ b/src/towncrier/newsfragments/369.feature.rst
@@ -1,0 +1,2 @@
+Added support to tables in toml settings, which provides a more intuitive
+way to configure custom types.

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -1,10 +1,12 @@
 # Copyright (c) Amber Brown, 2015
 # See LICENSE for details.
 
-from twisted.trial.unittest import TestCase
-
+import collections as clt
 import os
 from textwrap import dedent
+import textwrap
+
+from twisted.trial.unittest import TestCase
 
 from .._settings import load_config, ConfigError
 
@@ -172,7 +174,7 @@ package = "foobar"
             str(e.exception),
             "The template file '{}' does not exist.".format(
                 os.path.normpath(os.path.join(temp, "foo.rst")),
-            )
+            ),
         )
 
     def test_missing_template_in_towncrier(self):
@@ -199,3 +201,78 @@ package = "foobar"
         self.assertEqual(
             str(e.exception), "Towncrier does not have a template named 'foo'."
         )
+
+    def test_custom_types_as_tables_array_deprecated(self):
+        """
+        Custom fragment categories can be defined inside
+        the toml config file using an array of tables
+        (a table name in double brackets).
+
+        This functionality is considered deprecated, but we continue
+        to support it to keep backward compatibility.
+        """
+        toml_content = """
+        [tool.towncrier]
+        package = "foobar"
+        [[tool.towncrier.type]]
+        directory="foo"
+        name="Foo"
+        showcontent=false
+
+        [[tool.towncrier.type]]
+        directory="spam"
+        name="Spam"
+        showcontent=true
+        """
+        toml_content = textwrap.dedent(toml_content)
+        expected = [
+            (u"foo", {"name": u"Foo", "showcontent": False, }),
+            (u"spam", {"name": u"Spam", "showcontent": True, },),
+        ]
+        expected = clt.OrderedDict(expected)
+        config = self.load_config_from_string(toml_content, )
+        actual = config["types"]
+        self.assertDictEqual(expected, actual)
+
+    def test_custom_types_as_tables(self):
+        """
+        Custom fragment categories can be defined inside
+        the toml config file using tables.
+        """
+        test_project_path = self.mktemp()
+        os.makedirs(test_project_path)
+        toml_content = """
+        [tool.towncrier]
+        package = "foobar"
+        [tool.towncrier.fragment.feat]
+        ignored_field="Bazz"
+        [tool.towncrier.fragment.fix]
+        [tool.towncrier.fragment.chore]
+        name = "Other Tasks"
+        showcontent = false
+        """
+        toml_content = textwrap.dedent(toml_content)
+        expected = [
+            (u"chore", {"name": u"Other Tasks", "showcontent": False, }),
+            (u"feat", {"name": u"Feat", "showcontent": True, }),
+            (u"fix", {"name": u"Fix", "showcontent": True, }),
+        ]
+
+        expected = clt.OrderedDict(expected)
+        config = self.load_config_from_string(toml_content, )
+        actual = config["types"]
+        self.assertDictEqual(expected, actual)
+
+    def load_config_from_string(self, toml_content):
+        """Load configuration from a string.
+
+        Given a string following toml syntax,
+        obtain the towncrier configuration.
+        """
+        test_project_path = self.mktemp()
+        os.makedirs(test_project_path)
+        toml_path = os.path.join(test_project_path, "pyproject.toml")
+        with open(toml_path, "w") as f:
+            f.write(toml_content)
+        config = load_config(test_project_path)
+        return config


### PR DESCRIPTION
* Add support to toml tables for custom fragments,
  with default values.

Resolves: twisted/#369
Signed-off-by: danieljmv01 <danieljmv01@gmail.com>