### PR TITLE
Create message in command line

### DIFF
--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -94,7 +94,7 @@ def _get_news_content_from_user(message):
     if message is not None:
         initial_content += (
             "\n"
-            f"{message}\n"
+            "{message}\n".format(message=message)
         )
     content = click.edit(initial_content)
     if content is None:

--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -22,12 +22,17 @@ from ._settings import load_config_from_options
     default=False,
     help="Open an editor for writing the newsfragment content.",
 )  # TODO: default should be true
+@click.option(
+    "-m", "--message",
+    type=str,
+    help="Set message in new fragment."
+)
 @click.argument("filename")
-def _main(ctx, directory, config, filename, edit):
-    return __main(ctx, directory, config, filename, edit)
+def _main(ctx, directory, config, filename, edit, message):
+    return __main(ctx, directory, config, filename, edit, message)
 
 
-def __main(ctx, directory, config, filename, edit):
+def __main(ctx, directory, config, filename, edit, message):
     """
     The main entry point.
     """
@@ -66,9 +71,9 @@ def __main(ctx, directory, config, filename, edit):
         raise click.ClickException("{} already exists".format(segment_file))
 
     if edit:
-        content = _get_news_content_from_user()
+        content = _get_news_content_from_user(message)
     else:
-        content = "Add your info here"
+        content = message if message is not None else "Add your info here"
 
     if content is None:
         click.echo("Abort creating news fragment.")
@@ -80,12 +85,18 @@ def __main(ctx, directory, config, filename, edit):
     click.echo("Created news fragment at {}".format(segment_file))
 
 
-def _get_news_content_from_user():
-    content = click.edit(
+def _get_news_content_from_user(message):
+    initial_content = (
         "# Please write your news content. When finished, save the file.\n"
         "# In order to abort, exit without saving.\n"
         "# Lines starting with \"#\" are ignored.\n"
     )
+    if message is not None:
+        initial_content += (
+            "\n"
+            f"{message}\n"
+        )
+    content = click.edit(initial_content)
     if content is None:
         return None
     all_lines = content.split("\n")

--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -23,9 +23,9 @@ from ._settings import load_config_from_options
     help="Open an editor for writing the newsfragment content.",
 )  # TODO: default should be true
 @click.option(
-    "-m", "--message",
+    "-c", "--content",
     type=str,
-    help="Set message in new fragment."
+    help="Sets the content of the new fragment."
 )
 @click.argument("filename")
 def _main(ctx, directory, config, filename, edit, message):

--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -25,14 +25,15 @@ from ._settings import load_config_from_options
 @click.option(
     "-c", "--content",
     type=str,
+    default="Add your info here",
     help="Sets the content of the new fragment."
 )
 @click.argument("filename")
-def _main(ctx, directory, config, filename, edit, message):
-    return __main(ctx, directory, config, filename, edit, message)
+def _main(ctx, directory, config, filename, edit, content):
+    return __main(ctx, directory, config, filename, edit, content)
 
 
-def __main(ctx, directory, config, filename, edit, message):
+def __main(ctx, directory, config, filename, edit, content):
     """
     The main entry point.
     """
@@ -71,9 +72,7 @@ def __main(ctx, directory, config, filename, edit, message):
         raise click.ClickException("{} already exists".format(segment_file))
 
     if edit:
-        content = _get_news_content_from_user(message)
-    else:
-        content = message if message is not None else "Add your info here"
+        content = _get_news_content_from_user(content)
 
     if content is None:
         click.echo("Abort creating news fragment.")

--- a/src/towncrier/newsfragments/374.feature.rst
+++ b/src/towncrier/newsfragments/374.feature.rst
@@ -1,0 +1,2 @@
+
+Add -m flag to create endpoint

--- a/src/towncrier/newsfragments/374.feature.rst
+++ b/src/towncrier/newsfragments/374.feature.rst
@@ -1,2 +1,2 @@
 
-Add -m flag to create endpoint
+The `towncrier create` command line now has a new `-m TEXT` argument that is used to define the content of the newly created fragment.

--- a/src/towncrier/test/test_create.py
+++ b/src/towncrier/test/test_create.py
@@ -99,12 +99,20 @@ class TestCli(TestCase):
                 self.assertEqual(1, result.exit_code)
 
     def test_message(self):
-        """Set fragment message in command line"""
+        """
+        When creating a new fragment the content can be passed as a
+        command line argument.
+        The text editor is not invoked.
+        """
         message = "This is a message"
         self._test_success(content=[message], additional_args=["-m", message])
 
     def test_message_and_edit(self):
-        """Set fragment message in command line and edit"""
+        """
+        When creating a new message, a initial content can be passed via
+        the command line and continue modifying the content by invoking the
+        text editor.
+        """
         message = "This is a message"
         content = ["This is line 1\n", "This is line 2"]
         with mock.patch("click.edit") as mock_edit:

--- a/src/towncrier/test/test_create.py
+++ b/src/towncrier/test/test_create.py
@@ -119,7 +119,10 @@ class TestCli(TestCase):
         edit_content = ["This is line 1\n", "This is line 2"]
         with mock.patch("click.edit") as mock_edit:
             mock_edit.return_value = "".join(edit_content)
-            self._test_success(content=edit_content, additional_args=["-c", content_line, "--edit"])
+            self._test_success(
+                content=edit_content,
+                additional_args=["-c", content_line, "--edit"]
+            )
             mock_edit.assert_called_once_with(
                 "# Please write your news content. When finished, save the file.\n"
                 "# In order to abort, exit without saving.\n"

--- a/src/towncrier/test/test_create.py
+++ b/src/towncrier/test/test_create.py
@@ -71,6 +71,11 @@ class TestCli(TestCase):
         with mock.patch("click.edit") as mock_edit:
             mock_edit.return_value = "".join(content)
             self._test_success(content=content, additional_args=["--edit"])
+            mock_edit.assert_called_once_with(
+                "# Please write your news content. When finished, save the file.\n"
+                "# In order to abort, exit without saving.\n"
+                "# Lines starting with \"#\" are ignored.\n"
+            )
 
     def test_edit_with_comment(self):
         """Create file editly with ignored line."""
@@ -92,6 +97,26 @@ class TestCli(TestCase):
                 result = runner.invoke(_main, ["123.feature.rst", "--edit"])
                 self.assertEqual([], os.listdir("foo/newsfragments"))
                 self.assertEqual(1, result.exit_code)
+
+    def test_message(self):
+        """Set fragment message in command line"""
+        message = "This is a message"
+        self._test_success(content=[message], additional_args=["-m", message])
+
+    def test_message_and_edit(self):
+        """Set fragment message in command line and edit"""
+        message = "This is a message"
+        content = ["This is line 1\n", "This is line 2"]
+        with mock.patch("click.edit") as mock_edit:
+            mock_edit.return_value = "".join(content)
+            self._test_success(content=content, additional_args=["-m", message, "--edit"])
+            mock_edit.assert_called_once_with(
+                "# Please write your news content. When finished, save the file.\n"
+                "# In order to abort, exit without saving.\n"
+                "# Lines starting with \"#\" are ignored.\n"
+                "\n"
+                f"{message}\n"
+            )
 
     def test_different_directory(self):
         """Ensure non-standard directories are used."""

--- a/src/towncrier/test/test_create.py
+++ b/src/towncrier/test/test_create.py
@@ -75,6 +75,8 @@ class TestCli(TestCase):
                 "# Please write your news content. When finished, save the file.\n"
                 "# In order to abort, exit without saving.\n"
                 "# Lines starting with \"#\" are ignored.\n"
+                "\n"
+                "Add your info here\n"
             )
 
     def test_edit_with_comment(self):
@@ -98,14 +100,14 @@ class TestCli(TestCase):
                 self.assertEqual([], os.listdir("foo/newsfragments"))
                 self.assertEqual(1, result.exit_code)
 
-    def test_message(self):
+    def test_content(self):
         """
         When creating a new fragment the content can be passed as a
         command line argument.
         The text editor is not invoked.
         """
-        message = "This is a message"
-        self._test_success(content=[message], additional_args=["-m", message])
+        content_line = "This is a content"
+        self._test_success(content=[content_line], additional_args=["-c", content_line])
 
     def test_message_and_edit(self):
         """
@@ -113,17 +115,17 @@ class TestCli(TestCase):
         the command line and continue modifying the content by invoking the
         text editor.
         """
-        message = "This is a message"
-        content = ["This is line 1\n", "This is line 2"]
+        content_line = "This is a content line"
+        edit_content = ["This is line 1\n", "This is line 2"]
         with mock.patch("click.edit") as mock_edit:
-            mock_edit.return_value = "".join(content)
-            self._test_success(content=content, additional_args=["-m", message, "--edit"])
+            mock_edit.return_value = "".join(edit_content)
+            self._test_success(content=edit_content, additional_args=["-c", content_line, "--edit"])
             mock_edit.assert_called_once_with(
                 "# Please write your news content. When finished, save the file.\n"
                 "# In order to abort, exit without saving.\n"
                 "# Lines starting with \"#\" are ignored.\n"
                 "\n"
-                "{message}\n".format(message=message)
+                "{content_line}\n".format(content_line=content_line)
             )
 
     def test_different_directory(self):

--- a/src/towncrier/test/test_create.py
+++ b/src/towncrier/test/test_create.py
@@ -115,7 +115,7 @@ class TestCli(TestCase):
                 "# In order to abort, exit without saving.\n"
                 "# Lines starting with \"#\" are ignored.\n"
                 "\n"
-                f"{message}\n"
+                "{message}\n".format(message=message)
             )
 
     def test_different_directory(self):


### PR DESCRIPTION
Description
=======

When using `git` one can set a commit message using the `-m` flag. For example:
```
git commit -m "This is my message"
```

Taking inspiration from this, now *Towncrier* can also get a message from user using a `-m` flag:

```
towncrier create 123.feature -m "This is a message that describes the news fragment"
```
This feature plays nicely with the `--edit` flag.