### PR TITLE
Shrink CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,6 @@ jobs:
           - name: CPython 3.9
             tox: py39
             action: '3.9'
-          - name: PyPy 3.8
-            tox: pypy38
-            action: pypy-3.8
         task:
           - name: Test
             tox: tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
             tox: build
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up ${{ matrix.python.name }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python.action }}
 
@@ -46,26 +46,19 @@ jobs:
       run: tox -c tox.ini -e ${{ matrix.task.tox }}
 
     - name: Publish
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: dist
         path: dist/
 
-  test:
-    name: ${{ matrix.task.name}} - ${{ matrix.os.name }} ${{ matrix.python.name }}
-    runs-on: ${{ matrix.os.runs-on }}
+  test-linux:
+    name: ${{ matrix.task.name}} - Linux ${{ matrix.python.name }}
+    runs-on: ubuntu-latest
     needs:
       - build
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - name: Linux
-            runs-on: ubuntu-latest
-          - name: macOS
-            runs-on: macos-latest
-          - name: Win
-            runs-on: windows-latest
         python:
           - name: CPython 3.7
             tox: py37
@@ -90,16 +83,62 @@ jobs:
             tox: tests
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Download package files
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: dist
         path: dist/
 
     - name: Set up ${{ matrix.python.name }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python.action }}
+
+    - name: Install dependencies
+      run: python -m pip install --upgrade pip tox codecov
+
+    - uses: twisted/python-info-action@v1
+
+    - name: Tox
+      run: tox -c tox.ini --installpkg dist/*.whl -e ${{ matrix.python.tox }}-tests
+
+    - name: Codecov
+      run: |
+        codecov -n "GitHub Actions - ${{ matrix.task.name}} - ${{ matrix.os.name }} ${{ matrix.python.name }}"
+
+
+  test-windows:
+    name: ${{ matrix.task.name}} - Windows ${{ matrix.python.name }}
+    runs-on: windows-latest
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - name: CPython 3.9
+            tox: py39
+            action: '3.9'
+          - name: PyPy 3.8
+            tox: pypy38
+            action: pypy-3.8
+        task:
+          - name: Test
+            tox: tests
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Download package files
+      uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist/
+
+    - name: Set up ${{ matrix.python.name }}
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python.action }}
 
@@ -134,18 +173,18 @@ jobs:
             tox: check-newsfragment
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Download package files
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: dist
         path: dist/
 
     - name: Set up ${{ matrix.python.name }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python.action }}
 
@@ -164,18 +203,19 @@ jobs:
 
     needs:
       - build
-      - test
+      - test-linux
+      - test-windows
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Download package files
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: dist
         path: dist/
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.9
 
@@ -203,7 +243,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-      - test
+      - test-linux
+      - test-windows
       - check
       - pypi-publish
     steps:


### PR DESCRIPTION
Everything except Linux is very slow on GHA.

macOS is very similar to Linux, so we can safely drop it and it's fine to test
one CPython and one PyPy on Windows.

Saves the planet...eh... fixes #379