### PR TITLE
bugfix in _writer.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,14 +150,14 @@ Towncrier has the following global options, which can be specified in the toml f
     wrap = false  # Wrap text to 79 characters
     all_bullets = true  # make all fragments bullet points
 
-If ``single_file`` is set to ``true`` or unspecified, all changes will be written to a single 
+If ``single_file`` is set to ``true`` or unspecified, all changes will be written to a single
 fixed newsfile, whose name is literally fixed as the ``filename`` option. In each run of ``towncrier build``,
-content of new changes will append at the top of old content, and after ``start_string`` if the 
-``start_string`` already appears in the newsfile. If the corresponding ``top_line``, which is formatted 
-as the option 'title_format', already exists in newsfile, ``ValueError`` will be raised to remind 
+content of new changes will append at the top of old content, and after ``start_string`` if the
+``start_string`` already appears in the newsfile. If the corresponding ``top_line``, which is formatted
+as the option 'title_format', already exists in newsfile, ``ValueError`` will be raised to remind
 you "already produced newsfiles for this version".
 
-If ``single_file`` is set to ``false`` instead, each versioned ``towncrier build`` will generate a 
+If ``single_file`` is set to ``false`` instead, each versioned ``towncrier build`` will generate a
 separate newsfile, whose name is formatted as the patten given by option ``filename``.
 For example, if ``filename="{version}-notes.rst"``, then the release note with version "7.8.9" will
 be written to the file "7.8.9-notes.rst". If the newsfile already exists, its content

--- a/README.rst
+++ b/README.rst
@@ -150,7 +150,18 @@ Towncrier has the following global options, which can be specified in the toml f
     wrap = false  # Wrap text to 79 characters
     all_bullets = true  # make all fragments bullet points
 
-If a single file is used, the content of that file gets overwritten each time.
+If ``single_file`` is set to ``true`` or unspecified, all changes will be written to a single 
+fixed newsfile, whose name is literally fixed as the ``filename`` option. In each run of ``towncrier build``,
+content of new changes will append at the top of old content, and after ``start_string`` if the 
+``start_string`` already appears in the newsfile. If the corresponding ``top_line``, which is formatted 
+as the option 'title_format', already exists in newsfile, ``ValueError`` will be raised to remind 
+you "already produced newsfiles for this version".
+
+If ``single_file`` is set to ``false`` instead, each versioned ``towncrier build`` will generate a 
+separate newsfile, whose name is formatted as the patten given by option ``filename``.
+For example, if ``filename="{version}-notes.rst"``, then the release note with version "7.8.9" will
+be written to the file "7.8.9-notes.rst". If the newsfile already exists, its content
+will be overwriten with new release note, without throwing a ``ValueError`` warning.
 
 If ``title_format`` is unspecified or an empty string, the default format will be used.
 If set to ``false``, no title will be created.

--- a/src/towncrier/_writer.py
+++ b/src/towncrier/_writer.py
@@ -26,7 +26,7 @@ def append_to_newsfile(
     else:
         existing_content = [""]
 
-    if top_line and top_line in existing_content:
+    if top_line and top_line in existing_content[-1]:
         raise ValueError("It seems you've already produced newsfiles for this version?")
 
     with open(os.path.join(directory, filename), "wb") as f:

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -193,7 +193,7 @@ def __main(
         start_string = config["start_string"]
         news_file = config["filename"]
 
-        if config["single_file"]:
+        if not config["single_file"]:
             # When single_file is enabled, the news file name changes based on the version.
             news_file = news_file.format(
                 name=project_name, version=project_version, project_date=project_date

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -193,8 +193,9 @@ def __main(
         start_string = config["start_string"]
         news_file = config["filename"]
 
-        if not config["single_file"]:
-            # When single_file is enabled, the news file name changes based on the version.
+        if config["single_file"] is False:
+            # The release notes for each version are stored in a separate file.
+            # The name of that file is generated based on the current version and project.
             news_file = news_file.format(
                 name=project_name, version=project_version, project_date=project_date
             )

--- a/src/towncrier/newsfragments/391.bugfix
+++ b/src/towncrier/newsfragments/391.bugfix
@@ -1,0 +1,3 @@
+
+fix `single_file` option related newsfile naming and duplicate version
+writing behavior, to be consistent with documentation.

--- a/src/towncrier/newsfragments/391.bugfix
+++ b/src/towncrier/newsfragments/391.bugfix
@@ -1,3 +1,3 @@
+The detection of duplicate release notes was fixed and recording changes of same version is no longer triggered.
 
-fix `single_file` option related newsfile naming and duplicate version
-writing behavior, to be consistent with documentation.
+Support for having the release notes for each version in a separate file is working again. This is regression introduced in VERSION 19.9.0rc1.

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -2,8 +2,8 @@
 # See LICENSE for details.
 
 import os
-from pathlib import Path
 
+from pathlib import Path
 from subprocess import call
 from textwrap import dedent
 
@@ -525,7 +525,7 @@ class TestCli(TestCase):
                     "--date",
                     "01-01-2001",
                     "--yes",
-                ]
+                ],
             )
             # not git repository, manually remove fragment file
             Path(f"newsfragments/{fragment_file}").unlink()
@@ -538,12 +538,18 @@ class TestCli(TestCase):
                     '[tool.towncrier]\n single_file=false\n filename="{version}-notes.rst"'
                 )
             os.mkdir("newsfragments")
-            results.append(do_build_once_with("7.8.9", "123.feature", "Adds levitation"))
+            results.append(
+                do_build_once_with("7.8.9", "123.feature", "Adds levitation")
+            )
             results.append(do_build_once_with("7.9.0", "456.bugfix", "Adds catapult"))
 
             self.assertEqual(0, results[0].exit_code, results[0].output)
             self.assertEqual(0, results[1].exit_code, results[1].output)
-            self.assertEqual(2, len(list(Path.cwd().glob("*-notes.rst"))), "one newfile for each build")
+            self.assertEqual(
+                2,
+                len(list(Path.cwd().glob("*-notes.rst"))),
+                "one newfile for each build",
+            )
             self.assertTrue(os.path.exists("7.8.9-notes.rst"), os.listdir("."))
             self.assertTrue(os.path.exists("7.9.0-notes.rst"), os.listdir("."))
 
@@ -621,7 +627,7 @@ class TestCli(TestCase):
                     "--date",
                     "01-01-2001",
                     "--yes",
-                ]
+                ],
             )
             # not git repository, manually remove fragment file
             Path(f"newsfragments/{fragment_file}").unlink()
@@ -634,12 +640,18 @@ class TestCli(TestCase):
                     '[tool.towncrier]\n single_file=true\n filename="{version}-notes.rst"'
                 )
             os.mkdir("newsfragments")
-            results.append(do_build_once_with("7.8.9", "123.feature", "Adds levitation"))
+            results.append(
+                do_build_once_with("7.8.9", "123.feature", "Adds levitation")
+            )
             results.append(do_build_once_with("7.9.0", "456.bugfix", "Adds catapult"))
 
             self.assertEqual(0, results[0].exit_code, results[0].output)
             self.assertEqual(0, results[1].exit_code, results[1].output)
-            self.assertEqual(1, len(list(Path.cwd().glob("*-notes.rst"))), "single newfile for multiple builds")
+            self.assertEqual(
+                1,
+                len(list(Path.cwd().glob("*-notes.rst"))),
+                "single newfile for multiple builds",
+            )
             self.assertTrue(os.path.exists("{version}-notes.rst"), os.listdir("."))
 
             with open("{version}-notes.rst") as f:

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -2,6 +2,7 @@
 # See LICENSE for details.
 
 import os
+from pathlib import Path
 
 from subprocess import call
 from textwrap import dedent
@@ -500,54 +501,86 @@ class TestCli(TestCase):
             ).lstrip(),
         )
 
-    def test_single_file(self):
+    def test_single_file_false(self):
         """
-        Enabling the single file mode will write the changelog to a filename
-        that is formatted from the filename args.
+        Disabling the single file mode will write the changelog to a filename
+        that is formatted from the filename args, w.r.t. [documentation]
+        (https://towncrier.readthedocs.io/en/latest/index.html?highlight=single_file#further-options)
+        as:
+            single_file = true  # if false, filename is formatted like `title_format`.
         """
         runner = CliRunner()
 
-        with runner.isolated_filesystem():
-            with open("pyproject.toml", "w") as f:
-                f.write(
-                    '[tool.towncrier]\n single_file=true\n filename="{version}-notes.rst"'
-                )
-            os.mkdir("newsfragments")
-            with open("newsfragments/123.feature", "w") as f:
-                f.write("Adds levitation")
+        def do_build_once_with(version, fragment_file, fragment):
+            with open(f"newsfragments/{fragment_file}", "w") as f:
+                f.write(fragment)
 
             result = runner.invoke(
                 _main,
                 [
                     "--version",
-                    "7.8.9",
+                    version,
                     "--name",
                     "foo",
                     "--date",
                     "01-01-2001",
                     "--yes",
-                ],
+                ]
             )
+            # not git repository, manually remove fragment file
+            Path(f"newsfragments/{fragment_file}").unlink()
+            return result
 
-            self.assertEqual(0, result.exit_code, result.output)
+        results = []
+        with runner.isolated_filesystem():
+            with open("pyproject.toml", "w") as f:
+                f.write(
+                    '[tool.towncrier]\n single_file=false\n filename="{version}-notes.rst"'
+                )
+            os.mkdir("newsfragments")
+            results.append(do_build_once_with("7.8.9", "123.feature", "Adds levitation"))
+            results.append(do_build_once_with("7.9.0", "456.bugfix", "Adds catapult"))
+
+            self.assertEqual(0, results[0].exit_code, results[0].output)
+            self.assertEqual(0, results[1].exit_code, results[1].output)
+            self.assertEqual(2, len(list(Path.cwd().glob("*-notes.rst"))), "one newfile for each build")
             self.assertTrue(os.path.exists("7.8.9-notes.rst"), os.listdir("."))
+            self.assertTrue(os.path.exists("7.9.0-notes.rst"), os.listdir("."))
+
+            outputs = []
             with open("7.8.9-notes.rst") as f:
-                output = f.read()
+                outputs.append(f.read())
+            with open("7.9.0-notes.rst") as f:
+                outputs.append(f.read())
 
-        self.assertEqual(
-            output,
-            dedent(
+            self.assertEqual(
+                outputs[0],
+                dedent(
+                    """
+                foo 7.8.9 (01-01-2001)
+                ======================
+
+                Features
+                --------
+
+                - Adds levitation (#123)
                 """
-            foo 7.8.9 (01-01-2001)
-            ======================
+                ).lstrip(),
+            )
+            self.assertEqual(
+                outputs[1],
+                dedent(
+                    """
+                foo 7.9.0 (01-01-2001)
+                ======================
 
-            Features
-            --------
+                Bugfixes
+                --------
 
-            - Adds levitation (#123)
-            """
-            ).lstrip(),
-        )
+                - Adds catapult (#456)
+                """
+                ).lstrip(),
+            )
 
     def test_singlefile_errors_and_explains_cleanly(self):
         """
@@ -568,55 +601,73 @@ class TestCli(TestCase):
             result.output,
         )
 
-    def test_single_file_false(self):
+    def test_single_file(self):
         """
-        If formatting arguments are given in the filename arg and single_file is
-        false, the filename will not be formatted.
+        "If a single file is used, the content of that file gets overwritten each time."
         """
         runner = CliRunner()
 
-        with runner.isolated_filesystem():
-            with open("pyproject.toml", "w") as f:
-                f.write(
-                    '[tool.towncrier]\n single_file=false\n filename="{version}-notes.rst"'
-                )
-            os.mkdir("newsfragments")
-            with open("newsfragments/123.feature", "w") as f:
-                f.write("Adds levitation")
+        def do_build_once_with(version, fragment_file, fragment):
+            with open(f"newsfragments/{fragment_file}", "w") as f:
+                f.write(fragment)
 
             result = runner.invoke(
                 _main,
                 [
                     "--version",
-                    "7.8.9",
+                    version,
                     "--name",
                     "foo",
                     "--date",
                     "01-01-2001",
                     "--yes",
-                ],
+                ]
             )
+            # not git repository, manually remove fragment file
+            Path(f"newsfragments/{fragment_file}").unlink()
+            return result
 
-            self.assertEqual(0, result.exit_code, result.output)
+        results = []
+        with runner.isolated_filesystem():
+            with open("pyproject.toml", "w") as f:
+                f.write(
+                    '[tool.towncrier]\n single_file=true\n filename="{version}-notes.rst"'
+                )
+            os.mkdir("newsfragments")
+            results.append(do_build_once_with("7.8.9", "123.feature", "Adds levitation"))
+            results.append(do_build_once_with("7.9.0", "456.bugfix", "Adds catapult"))
+
+            self.assertEqual(0, results[0].exit_code, results[0].output)
+            self.assertEqual(0, results[1].exit_code, results[1].output)
+            self.assertEqual(1, len(list(Path.cwd().glob("*-notes.rst"))), "single newfile for multiple builds")
             self.assertTrue(os.path.exists("{version}-notes.rst"), os.listdir("."))
-            self.assertFalse(os.path.exists("7.8.9-notes.rst"), os.listdir("."))
+
             with open("{version}-notes.rst") as f:
                 output = f.read()
 
-        self.assertEqual(
-            output,
-            dedent(
+            self.assertEqual(
+                output,
+                dedent(
+                    """
+                foo 7.9.0 (01-01-2001)
+                ======================
+
+                Bugfixes
+                --------
+
+                - Adds catapult (#456)
+
+
+                foo 7.8.9 (01-01-2001)
+                ======================
+
+                Features
+                --------
+
+                - Adds levitation (#123)
                 """
-            foo 7.8.9 (01-01-2001)
-            ======================
-
-            Features
-            --------
-
-            - Adds levitation (#123)
-            """
-            ).lstrip(),
-        )
+                ).lstrip(),
+            )
 
     def test_bullet_points_false(self):
         """

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -532,11 +532,14 @@ class TestCli(TestCase):
         results = []
         with runner.isolated_filesystem():
             with open("pyproject.toml", "w") as f:
-                f.write('\n'.join([
-                    '[tool.towncrier]',
-                    ' single_file=false',
-                    ' filename="{version}-notes.rst"',
-                    ])
+                f.write(
+                    "\n".join(
+                        [
+                            "[tool.towncrier]",
+                            " single_file=false",
+                            ' filename="{version}-notes.rst"',
+                        ]
+                    )
                 )
             os.mkdir("newsfragments")
             results.append(
@@ -612,7 +615,7 @@ class TestCli(TestCase):
         """
         When `single_file = true` the single file is used to store the notes
         for multiple versions.
-        
+
         The name of the file is fixed as the literal option `filename` option
         in the configuration file, instead of extrapolated with variables.
         """
@@ -641,12 +644,15 @@ class TestCli(TestCase):
         results = []
         with runner.isolated_filesystem():
             with open("pyproject.toml", "w") as f:
-                f.write('\n'.join([
-                    '[tool.towncrier]',
-                    ' single_file=true',
-                    ' # The `filename` variable is fixed and not formated in any way.',
-                    ' filename="{version}-notes.rst"',
-                    ])
+                f.write(
+                    "\n".join(
+                        [
+                            "[tool.towncrier]",
+                            " single_file=true",
+                            " # The `filename` variable is fixed and not formated in any way.",
+                            ' filename="{version}-notes.rst"',
+                        ]
+                    )
                 )
             os.mkdir("newsfragments")
             results.append(

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -501,13 +501,11 @@ class TestCli(TestCase):
             ).lstrip(),
         )
 
-    def test_single_file_false(self):
+    def test_release_notes_in_separate_files(self):
         """
-        Disabling the single file mode will write the changelog to a filename
-        that is formatted from the filename args, w.r.t. [documentation]
-        (https://towncrier.readthedocs.io/en/latest/index.html?highlight=single_file#further-options)
-        as:
-            single_file = true  # if false, filename is formatted like `title_format`.
+        When `single_file = false` the release notes for each version are stored
+        in a separate file.
+        The name of the file is defined by the `filename` configuration value.
         """
         runner = CliRunner()
 
@@ -534,8 +532,11 @@ class TestCli(TestCase):
         results = []
         with runner.isolated_filesystem():
             with open("pyproject.toml", "w") as f:
-                f.write(
-                    '[tool.towncrier]\n single_file=false\n filename="{version}-notes.rst"'
+                f.write('\n'.join([
+                    '[tool.towncrier]',
+                    ' single_file=false',
+                    ' filename="{version}-notes.rst"',
+                    ])
                 )
             os.mkdir("newsfragments")
             results.append(
@@ -607,9 +608,13 @@ class TestCli(TestCase):
             result.output,
         )
 
-    def test_single_file(self):
+    def test_all_version_notes_in_a_single_file(self):
         """
-        "If a single file is used, the content of that file gets overwritten each time."
+        When `single_file = true` the single file is used to store the notes
+        for multiple versions.
+        
+        The name of the file is fixed as the literal option `filename` option
+        in the configuration file, instead of extrapolated with variables.
         """
         runner = CliRunner()
 
@@ -636,8 +641,12 @@ class TestCli(TestCase):
         results = []
         with runner.isolated_filesystem():
             with open("pyproject.toml", "w") as f:
-                f.write(
-                    '[tool.towncrier]\n single_file=true\n filename="{version}-notes.rst"'
+                f.write('\n'.join([
+                    '[tool.towncrier]',
+                    ' single_file=true',
+                    ' # The `filename` variable is fixed and not formated in any way.',
+                    ' filename="{version}-notes.rst"',
+                    ])
                 )
             os.mkdir("newsfragments")
             results.append(

--- a/src/towncrier/test/test_write.py
+++ b/src/towncrier/test/test_write.py
@@ -2,9 +2,9 @@
 # See LICENSE for details.
 
 import os
-from pathlib import Path
 
 from collections import OrderedDict
+from pathlib import Path
 from textwrap import dedent
 
 import pkg_resources
@@ -12,9 +12,9 @@ import pkg_resources
 from click.testing import CliRunner
 from twisted.trial.unittest import TestCase
 
-from ..build import _main
 from .._builder import render_fragments, split_fragments
 from .._writer import append_to_newsfile
+from ..build import _main
 
 
 class WritingTests(TestCase):
@@ -302,13 +302,15 @@ Old text.
         # `single_file` default as true
         with runner.isolated_filesystem():
             with open("pyproject.toml", "w") as f:
-                f.write(dedent(
-                    """
+                f.write(
+                    dedent(
+                        """
                     [tool.towncrier]
                     title_format="{name} {version} ({project_date})"
                     filename="{version}-notes.rst"
                     """
-                ).lstrip())
+                    ).lstrip()
+                )
             with open("{version}-notes.rst", "w") as f:
                 f.write("Release Notes\n\n.. towncrier release notes start\n")
             os.mkdir("newsfragments")
@@ -319,8 +321,9 @@ Old text.
             result = do_build_once()
             self.assertNotEqual(0, result.exit_code)
             self.assertIsInstance(result.exception, ValueError)
-            self.assertSubstring("already produced newsfiles for this version",
-                result.exception.args[0])
+            self.assertSubstring(
+                "already produced newsfiles for this version", result.exception.args[0]
+            )
 
     def test_single_file_false_overwrite_duplicate_version(self):
         """
@@ -350,14 +353,16 @@ Old text.
         # single_file = false
         with runner.isolated_filesystem():
             with open("pyproject.toml", "w") as f:
-                f.write(dedent(
-                    """
+                f.write(
+                    dedent(
+                        """
                     [tool.towncrier]
                     single_file=false
                     title_format="{name} {version} ({project_date})"
                     filename="{version}-notes.rst"
                     """
-                ).lstrip())
+                    ).lstrip()
+                )
             os.mkdir("newsfragments")
 
             result = do_build_once()
@@ -366,7 +371,7 @@ Old text.
             result = do_build_once()
             self.assertEqual(0, result.exit_code)
 
-            notes = list(Path.cwd().glob('*-notes.rst'))
+            notes = list(Path.cwd().glob("*-notes.rst"))
             self.assertEqual(1, len(notes))
             self.assertEqual("7.8.9-notes.rst", notes[0].name)
 


### PR DESCRIPTION
the version-already-produced error raising cannot be reached in expected single file mode like the test case in :test_write:WritingTests.test_append_at_top_with_hint