### PR TITLE
Enforce PR failure based on a single job and fail the job if a dependent job was skipped.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
         verbose: true
 
   all:
-    name: All
+    name: All success
     runs-on: ubuntu-latest
     needs:
       - build
@@ -245,6 +245,13 @@ jobs:
       - check
       - pypi-publish
     steps:
-      - name: This
+      - name: Require all successes
         shell: python
-        run: import this
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          import json
+          import os
+          import sys
+          results = json.loads(os.environ["RESULTS"])
+          sys.exit(0 if all(result == "success" for result in results) else 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,11 +235,19 @@ jobs:
         password: ${{ secrets.PYPI_TOKEN }}
         verbose: true
 
+  # This is a meta-job to simplify PR CI enforcement configuration in GitHub.
+  # Inside the GitHub config UI you only configure this job as required.
+  # All the extra requirements are defined "as code" as part of the `needs`
+  # list for this job.
   all:
     name: All success
     runs-on: ubuntu-latest
+    # The always() part is very important.
+    # If not set, the job will be skipped on failing dependencies.
     if: always()
     needs:
+      # This is the list of CI job that we are interested to be green before
+      # a merge.
       - build
       - test-linux
       - test-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,7 @@ jobs:
   all:
     name: All success
     runs-on: ubuntu-latest
+    if: always()
     needs:
       - build
       - test-linux


### PR DESCRIPTION
This tries to work around an issue with GitHub.

We have a PR configured to allowing merging only if Job A is green.

If you have a job A depending on another job B, if job B fails, job A is skipped.


But with job A skipped, GitHub is happy and it allows the PR to be merged.

Implement the nice move from @altendky from https://github.com/Chia-Network/chia-blockchain/pull/11880/