### PR TITLE
Run check-manifest and other linters via GitHub Actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,39 +151,21 @@ jobs:
       run: |
         codecov -n "GitHub Actions - ${{ matrix.task.name}} - ${{ matrix.os.name }} ${{ matrix.python.name }}"
 
-  check:
-    name: ${{ matrix.task.name}} - ${{ matrix.python.name }}
+  lint:
+    name: Linters
     runs-on: ubuntu-latest
-    needs:
-      - build
-    strategy:
-      fail-fast: false
-      matrix:
-        python:
-          # Using second most recent minor release for whatever little
-          # increase in stability over using the latest minor.
-          - name: CPython 3.9
-            tox: py39
-            action: 3.9
-        task:
-          - name: Check Newsfragment
-            tox: check-newsfragment
+    env:
+      TOX_PARALLEL_NO_SPINNER: 1
 
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
-    - name: Download package files
-      uses: actions/download-artifact@v3
-      with:
-        name: dist
-        path: dist/
-
-    - name: Set up ${{ matrix.python.name }}
+    - name: Set up python
       uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.python.action }}
+        python-version: "3.10"
 
     - name: Install dependencies
       run: python -m pip install --upgrade pip tox
@@ -191,7 +173,14 @@ jobs:
     - uses: twisted/python-info-action@v1
 
     - name: Tox
-      run: tox -c tox.ini -e ${{ matrix.task.tox }}
+      run: tox -c tox.ini --parallel -e pre-commit
+
+    - name: Tox
+      run: tox -c tox.ini --parallel -e check-newsfragment
+
+    - name: Tox
+      run: tox -c tox.ini --parallel -e check-manifest
+
 
   pypi-publish:
     # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,21 +151,43 @@ jobs:
       run: |
         codecov -n "GitHub Actions - ${{ matrix.task.name}} - ${{ matrix.os.name }} ${{ matrix.python.name }}"
 
-  lint:
-    name: Linters
+  check:
+    name: ${{ matrix.task.name}} - ${{ matrix.python.name }}
     runs-on: ubuntu-latest
-    env:
-      TOX_PARALLEL_NO_SPINNER: 1
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          # Using second most recent minor release for whatever little
+          # increase in stability over using the latest minor.
+          - name: CPython 3.9
+            tox: py39
+            python-version: '3.9'
+        task:
+          - name: Check Newsfragment
+            tox: check-newsfragment
+          - name: Check package manifest
+            tox: check-manifest
+          - name: Check pre-commit
+            tox: pre-commir
 
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
-    - name: Set up python
+    - name: Download package files
+      uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist/
+
+    - name: Set up ${{ matrix.python.name }}
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python.python-version }}
 
     - name: Install dependencies
       run: python -m pip install --upgrade pip tox
@@ -173,14 +195,7 @@ jobs:
     - uses: twisted/python-info-action@v1
 
     - name: Tox
-      run: tox -c tox.ini --parallel -e pre-commit
-
-    - name: Tox
-      run: tox -c tox.ini --parallel -e check-newsfragment
-
-    - name: Tox
-      run: tox -c tox.ini --parallel -e check-manifest
-
+      run: tox -c tox.ini -e ${{ matrix.task.tox }}
 
   pypi-publish:
     # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
           - name: Check package manifest
             tox: check-manifest
           - name: Check pre-commit
-            tox: pre-commir
+            tox: pre-commit
 
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,6 @@ repos:
     rev: 4.0.1
     hooks:
     - id: flake8
-      language_version: python3.10
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -69,7 +69,7 @@ We recommend the following workflow:
       *Running the test suite* for details.
 
 
-   c. Document any user-facing changes in one of the `/docs/` files.
+   c. Document any user-facing changes in one of the ``/docs/`` files.
 
    d. Create a newsfragment in ``src/towncrier/newsfragments/`` describing the changes and containing information that is of interest to end-users.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,7 +5,7 @@ Want to contribute to this project? Great! We'd love to hear from you!
 
 As a developer and user, you probably have some questions about our
 project and how to contribute.
-In this article we try to answer these and give you some recommendations.
+In this article, we try to answer these and give you some recommendations.
 
 
 Ways to communicate and contribute
@@ -28,10 +28,11 @@ There are several options to contribute to this project:
   If you found a bug or have a new cool feature, describe your findings.
   Try to be as descriptive as possible to help us understand your issue.
 
-* Check out the Freenode ``#twisted-dev`` IRC channel.
+* Check out the Libera ``#twisted`` IRC channel or `Twisted Gitter <https://gitter.im/twisted/twisted>`_.
 
-  If you prefer to discuss some topics personally, you may find the IRC
-  channel interesting.
+  If you prefer to discuss some topics personally,
+  you may find the IRC or Gitter channels interesting.
+  They are bridged.
 
 * Modify the code.
 
@@ -68,12 +69,14 @@ We recommend the following workflow:
       *Running the test suite* for details.
 
 
-   c. Document any user facing changes in one of the `/docs/` files.
+   c. Document any user-facing changes in one of the `/docs/` files.
 
-   d. Create a newsfragment in ``src/towncrier/newsfragments/`` describing the changes and containing information that are of interest for end-users.
+   d. Create a newsfragment in ``src/towncrier/newsfragments/`` describing the changes and containing information that is of interest to end-users.
 
    e. Create a `pull request`_.
-      Describe in the pull request what you did and why. If you have open questions, ask.
+      Describe in the pull request what you did and why.
+      If you have open questions, ask.
+      (optional) Allow team members to edit the code on your PR.
 
 #. Wait for feedback. If you receive any comments, address these.
 
@@ -98,7 +101,7 @@ The following list contains some ways how to run the test suite:
   You may want to add the ``--skip-missing-interpreters`` option to avoid errors
   when a specific Python interpreter version couldn't be found.
 
-*  To get a complete list about the available targets, run::
+*  To get a complete list of the available targets, run::
 
     $ tox -av
 
@@ -108,15 +111,13 @@ The following list contains some ways how to run the test suite:
     $ tox -- towncrier.test.test_project.InvocationTests.test_version
 
 * To run some quality checks before you create the pull request,
-  we recommend to use this call::
+  we recommend using this call::
 
-    $ tox -e check-manifest,check-newsfragment
+    $ tox -e pre-commit,check-manifest,check-newsfragment
 
-* Install `pre-commit <https://pre-commit.com/>`_ and activate::
+* Or enable `pre-commit` as a git hook::
 
     $ pip install pre-commit
-    $ pre-commit
-    Or run as git hook
     $ pre-commit install
 
 * To investigate and debug errors, use the ``trial`` command like this::

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+# Allow for longer test strings. Code is formatted to 88 columns by Black.
+max-line-length = 99

--- a/tox.ini
+++ b/tox.ini
@@ -34,3 +34,18 @@ commands =
    coverage run -p --module twisted.trial {posargs:towncrier}
    coverage combine -a
    coverage report
+
+[testenv:build]
+allowlist_externals =
+   bash
+changedir = {envtmpdir}
+deps =
+   build
+   check-manifest>=0.44
+   twine
+setenv =
+   toxinidir={toxinidir}
+skip_install = true
+commands =
+   # could be brought inside tox.ini after https://github.com/tox-dev/tox/issues/1571
+   bash {toxinidir}/tox_build.sh

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = cov-erase, pre-commit, {pypy37,pypy38,py37,py38,py39,py310}-tests, flake8, check-manifest, check-newsfragment, cov-report
+envlist = cov-erase, pre-commit, {pypy37,pypy38,py37,py38,py39,py310}-tests, check-manifest, check-newsfragment
 isolated_build=true
 skip_missing_envs = true
 
@@ -33,37 +33,4 @@ commands =
    # specifying the entry point script in `{envbindir}`.
    coverage run -p --module twisted.trial {posargs:towncrier}
    coverage combine -a
-
-[testenv:build]
-allowlist_externals =
-   bash
-changedir = {envtmpdir}
-deps =
-   build
-   check-manifest>=0.44
-   twine
-setenv =
-   toxinidir={toxinidir}
-skip_install = true
-commands =
-   # could be brought inside tox.ini after https://github.com/tox-dev/tox/issues/1571
-   bash {toxinidir}/tox_build.sh
-
-[testenv:cov-report]
-deps =
-   coverage
-skip_install = true
-commands =
-   coverage html
    coverage report
-
-[testenv:cov-erase]
-deps =
-   coverage
-skip_install = true
-commands =
-   coverage erase
-
-[flake8]
-# Allow for longer test strings. Code is formatted to 88 columns by Black.
-max-line-length = 99


### PR DESCRIPTION
# Description

This is take2 for #292 

Enabled check manifest and pre-comit as part of GitHub Actions CI

We have pre-commit hook so I am not sure if this is needed.

I  tried to simplify the job and removed the job matrix.

Fixes #292

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [NA] Make sure changes are covered by existing or new tests.
* [NA] For at least one Python version, make sure local test run is green.
* [X] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [X] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
