### PR TITLE
Refactor _get_default_compare_branch

### DIFF
--- a/src/towncrier/check.py
+++ b/src/towncrier/check.py
@@ -19,11 +19,13 @@ def _run(args, **kwargs):
     return check_output(args, **kwargs)
 
 
-def get_default_compare_branch(base_directory, encoding):
-    branches = (
-        _run(["git", "branch", "-r"], cwd=base_directory).decode(encoding).splitlines()
-    )
-    branches = [branch.strip() for branch in branches]
+def _get_remote_branches(base_directory, encoding):
+    output = _run(["git", "branch", "-r"], cwd=base_directory).decode(encoding)
+
+    return [branch.strip() for branch in output.splitlines()]
+
+
+def _get_default_compare_branch(branches):
     if "origin/main" in branches:
         return "origin/main"
     if "origin/master" in branches:
@@ -78,8 +80,8 @@ def __main(comparewith, directory, config):
     # and also some CI such as GitHub Actions).
     encoding = getattr(sys.stdout, "encoding", "utf8")
     if comparewith is None:
-        comparewith = get_default_compare_branch(
-            base_directory=base_directory, encoding=encoding
+        comparewith = _get_default_compare_branch(
+            _get_remote_branches(base_directory=base_directory, encoding=encoding)
         )
 
     if comparewith is None:

--- a/src/towncrier/test/test_check.py
+++ b/src/towncrier/test/test_check.py
@@ -6,7 +6,6 @@ import os.path
 import sys
 
 from subprocess import PIPE, Popen, call
-from unittest.mock import patch
 
 from click.testing import CliRunner
 from twisted.trial.unittest import TestCase
@@ -292,14 +291,7 @@ class TestChecker(TestCase):
         """
         If there's a remote branch origin/main, prefer it over everything else.
         """
-        runner = CliRunner()
-
-        with runner.isolated_filesystem():
-            create_project()
-
-            with patch("towncrier.check._run") as m:
-                m.return_value = b"  origin/master\n  origin/main\n\n"
-                branch = check.get_default_compare_branch(".", "utf-8")
+        branch = check._get_default_compare_branch(["origin/master", "origin/main"])
 
         self.assertEqual("origin/main", branch)
 
@@ -307,13 +299,6 @@ class TestChecker(TestCase):
         """
         If there's origin/master and no main, use it.
         """
-        runner = CliRunner()
-
-        with runner.isolated_filesystem():
-            create_project()
-
-            with patch("towncrier.check._run") as m:
-                m.return_value = b"  origin/master\n  origin/foo\n\n"
-                branch = check.get_default_compare_branch(".", "utf-8")
+        branch = check._get_default_compare_branch(["origin/master", "origin/foo"])
 
         self.assertEqual("origin/master", branch)


### PR DESCRIPTION
I couldn't live with myself contributing monkeypatching a mock, so here's a clean fix:

Make it a computation instead of an action and drop the patch/mock.