### PR TITLE
Make configuration a proper class, push settings & check coverage to 100%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,10 @@ source = ["src", ".tox/*/site-packages"]
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+]
 omit = [
     "src/towncrier/__main__.py",
     "src/towncrier/test/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ line_length = 88
 strict = true
 # 2022-09-04: Trial's API isn't annotated yet, which limits the usefulness of type-checking
 #             the unit tests. Therefore they have not been annotated yet.
-exclude = '^src/towncrier/test/.*\.py$'
+exclude = '^src/towncrier/test/test_.*\.py$'
 
 [[tool.mypy.overrides]]
 module = 'click_default_group'

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -9,7 +9,7 @@ import textwrap
 import traceback
 
 from collections import OrderedDict, defaultdict
-from typing import Any, DefaultDict, Iterator, Mapping, Sequence
+from typing import Any, DefaultDict, Iterable, Iterator, Mapping, Sequence
 
 from jinja2 import Template
 
@@ -28,7 +28,7 @@ def strip_if_integer_string(s: str) -> str:
 # Returns ticket, category and counter or (None, None, None) if the basename
 # could not be parsed or doesn't contain a valid category.
 def parse_newfragment_basename(
-    basename: str, definitions: Sequence[str]
+    basename: str, frag_type_names: Iterable[str]
 ) -> tuple[str, str, int] | tuple[None, None, None]:
     invalid = (None, None, None)
     parts = basename.split(".")
@@ -38,14 +38,14 @@ def parse_newfragment_basename(
     if len(parts) == 2:
         ticket, category = parts
         ticket = strip_if_integer_string(ticket)
-        return (ticket, category, 0) if category in definitions else invalid
+        return (ticket, category, 0) if category in frag_type_names else invalid
 
     # There are at least 3 parts. Search for a valid category from the second
     # part onwards.
     # The category is used as the reference point in the parts list to later
     # infer the issue number and counter value.
     for i in range(1, len(parts)):
-        if parts[i] in definitions:
+        if parts[i] in frag_type_names:
             # Current part is a valid category according to given definitions.
             category = parts[i]
             # Use the previous part as the ticket number.
@@ -83,7 +83,7 @@ def find_fragments(
     base_directory: str,
     sections: Mapping[str, str],
     fragment_directory: str | None,
-    definitions: Sequence[str],
+    frag_type_names: Iterable[str],
     orphan_prefix: str | None = None,
 ) -> tuple[Mapping[str, Mapping[tuple[str, str, int], str]], list[str]]:
     """
@@ -115,7 +115,7 @@ def find_fragments(
         for basename in files:
 
             ticket, category, counter = parse_newfragment_basename(
-                basename, definitions
+                basename, frag_type_names
             )
             if category is None:
                 continue
@@ -244,7 +244,7 @@ def render_fragments(
     template: str,
     issue_format: str | None,
     fragments: Mapping[str, Mapping[str, Mapping[str, Sequence[str]]]],
-    definitions: Sequence[str],
+    definitions: Mapping[str, Mapping[str, Any]],
     underlines: Sequence[str],
     wrap: bool,
     versiondata: Mapping[str, str],

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -114,51 +114,49 @@ def __main(
     to_err = draft
 
     click.echo("Loading template...", err=to_err)
-    with open(config["template"], "rb") as tmpl:
+    with open(config.template, "rb") as tmpl:
         template = tmpl.read().decode("utf8")
 
     click.echo("Finding news fragments...", err=to_err)
 
-    definitions = config["types"]
+    definitions = config.types
 
-    if config.get("directory"):
-        fragment_base_directory = os.path.abspath(config["directory"])
+    if config.directory:
+        fragment_base_directory = os.path.abspath(config.directory)
         fragment_directory = None
     else:
         fragment_base_directory = os.path.abspath(
-            os.path.join(base_directory, config["package_dir"], config["package"])
+            os.path.join(base_directory, config.package_dir, config.package)
         )
         fragment_directory = "newsfragments"
 
     fragment_contents, fragment_filenames = find_fragments(
         fragment_base_directory,
-        config["sections"],
+        config.sections,
         fragment_directory,
         definitions,
-        config["orphan_prefix"],
+        config.orphan_prefix,
     )
 
     click.echo("Rendering news fragments...", err=to_err)
     fragments = split_fragments(
-        fragment_contents, definitions, all_bullets=config["all_bullets"]
+        fragment_contents, definitions, all_bullets=config.all_bullets
     )
 
     if project_version is None:
-        project_version = config.get("version")
+        project_version = config.version
         if project_version is None:
             project_version = get_version(
-                os.path.join(base_directory, config["package_dir"]), config["package"]
+                os.path.join(base_directory, config.package_dir), config.package
             ).strip()
 
     if project_name is None:
-        project_name = config.get("name")
+        project_name = config.name
         if not project_name:
-            package = config.get("package")
+            package = config.package
             if package:
                 project_name = get_project_name(
-                    os.path.abspath(
-                        os.path.join(base_directory, config["package_dir"])
-                    ),
+                    os.path.abspath(os.path.join(base_directory, config.package_dir)),
                     package,
                 )
             else:
@@ -168,13 +166,13 @@ def __main(
     if project_date is None:
         project_date = _get_date().strip()
 
-    if config["title_format"]:
-        top_line = config["title_format"].format(
+    if config.title_format:
+        top_line = config.title_format.format(
             name=project_name, version=project_version, project_date=project_date
         )
         render_title_with_fragments = False
         render_title_separately = True
-    elif config["title_format"] is False:
+    elif config.title_format is False:
         # This is an odd check but since we support both "" and False with
         # different effects we have to do something a bit abnormal here.
         top_line = ""
@@ -188,14 +186,14 @@ def __main(
     rendered = render_fragments(
         # The 0th underline is used for the top line
         template,
-        config["issue_format"],
+        config.issue_format,
         fragments,
         definitions,
-        config["underlines"][1:],
-        config["wrap"],
+        config.underlines[1:],
+        config.wrap,
         {"name": project_name, "version": project_version, "date": project_date},
-        top_underline=config["underlines"][0],
-        all_bullets=config["all_bullets"],
+        top_underline=config.underlines[0],
+        all_bullets=config.all_bullets,
         render_title=render_title_with_fragments,
     )
 
@@ -203,7 +201,7 @@ def __main(
         content = "\n".join(
             [
                 top_line,
-                config["underlines"][0] * len(top_line),
+                config.underlines[0] * len(top_line),
                 rendered,
             ]
         )
@@ -219,10 +217,10 @@ def __main(
         click.echo(content)
     else:
         click.echo("Writing to newsfile...", err=to_err)
-        start_string = config["start_string"]
-        news_file = config["filename"]
+        start_string = config.start_string
+        news_file = config.filename
 
-        if config["single_file"] is False:
+        if config.single_file is False:
             # The release notes for each version are stored in a separate file.
             # The name of that file is generated based on the current version and project.
             news_file = news_file.format(
@@ -235,7 +233,7 @@ def __main(
             start_string,
             top_line,
             content,
-            single_file=config["single_file"],
+            single_file=config.single_file,
         )
 
         click.echo("Staging newsfile...", err=to_err)

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -119,7 +119,7 @@ def __main(
 
     click.echo("Finding news fragments...", err=to_err)
 
-    if config.directory:
+    if config.directory is not None:
         fragment_base_directory = os.path.abspath(config.directory)
         fragment_directory = None
     else:

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -119,8 +119,6 @@ def __main(
 
     click.echo("Finding news fragments...", err=to_err)
 
-    definitions = config.types
-
     if config.directory:
         fragment_base_directory = os.path.abspath(config.directory)
         fragment_directory = None
@@ -134,13 +132,13 @@ def __main(
         fragment_base_directory,
         config.sections,
         fragment_directory,
-        definitions,
+        config.types,
         config.orphan_prefix,
     )
 
     click.echo("Rendering news fragments...", err=to_err)
     fragments = split_fragments(
-        fragment_contents, definitions, all_bullets=config.all_bullets
+        fragment_contents, config.types, all_bullets=config.all_bullets
     )
 
     if project_version is None:
@@ -188,7 +186,7 @@ def __main(
         template,
         config.issue_format,
         fragments,
-        definitions,
+        config.types,
         config.underlines[1:],
         config.wrap,
         {"name": project_name, "version": project_version, "date": project_date},
@@ -217,7 +215,6 @@ def __main(
         click.echo(content)
     else:
         click.echo("Writing to newsfile...", err=to_err)
-        start_string = config.start_string
         news_file = config.filename
 
         if config.single_file is False:
@@ -230,7 +227,7 @@ def __main(
         append_to_newsfile(
             base_directory,
             news_file,
-            start_string,
+            config.start_string,
             top_line,
             content,
             single_file=config.single_file,

--- a/src/towncrier/check.py
+++ b/src/towncrier/check.py
@@ -104,17 +104,17 @@ def __main(
         click.echo(f"{n}. {change}")
     click.echo("----")
 
-    news_file = os.path.normpath(os.path.join(base_directory, config["filename"]))
+    news_file = os.path.normpath(os.path.join(base_directory, config.filename))
     if news_file in files:
         click.echo("Checks SKIPPED: news file changes detected.")
         sys.exit(0)
 
-    if config.get("directory"):
-        fragment_base_directory = os.path.abspath(config["directory"])
+    if config.directory:
+        fragment_base_directory = os.path.abspath(config.directory)
         fragment_directory = None
     else:
         fragment_base_directory = os.path.abspath(
-            os.path.join(base_directory, config["package_dir"], config["package"])
+            os.path.join(base_directory, config.package_dir, config.package)
         )
         fragment_directory = "newsfragments"
 
@@ -122,9 +122,9 @@ def __main(
         os.path.normpath(path)
         for path in find_fragments(
             fragment_base_directory,
-            config["sections"],
+            config.sections,
             fragment_directory,
-            config["types"],
+            config.types.keys(),
         )[1]
     }
     fragments_in_branch = fragments & files

--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -81,8 +81,8 @@ def __main(
     """
     base_directory, config = load_config_from_options(directory, config_path)
 
-    definitions = config["types"] or []
-    orphan_prefix = config["orphan_prefix"]
+    definitions = config.types or {}
+    orphan_prefix = config.orphan_prefix
     if orphan_prefix and filename.startswith(f"{orphan_prefix}."):
         # Append a random hex string to the orphan news fragment base name.
         filename = f"{orphan_prefix}{os.urandom(4).hex()}{filename[1:]}"
@@ -96,16 +96,16 @@ def __main(
             "one of: {}".format(filename, ", ".join(definitions))
         )
 
-    if config.get("directory"):
+    if config.directory:
         fragments_directory = os.path.abspath(
-            os.path.join(base_directory, config["directory"])
+            os.path.join(base_directory, config.directory)
         )
     else:
         fragments_directory = os.path.abspath(
             os.path.join(
                 base_directory,
-                config["package_dir"],
-                config["package"],
+                config.package_dir,
+                config.package,
                 "newsfragments",
             )
         )

--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -81,19 +81,17 @@ def __main(
     """
     base_directory, config = load_config_from_options(directory, config_path)
 
-    definitions = config.types or {}
-    orphan_prefix = config.orphan_prefix
-    if orphan_prefix and filename.startswith(f"{orphan_prefix}."):
+    if config.orphan_prefix and filename.startswith(f"{config.orphan_prefix}."):
         # Append a random hex string to the orphan news fragment base name.
-        filename = f"{orphan_prefix}{os.urandom(4).hex()}{filename[1:]}"
+        filename = f"{config.orphan_prefix}{os.urandom(4).hex()}{filename[1:]}"
     if len(filename.split(".")) < 2 or (
-        filename.split(".")[-1] not in definitions
-        and filename.split(".")[-2] not in definitions
+        filename.split(".")[-1] not in config.types
+        and filename.split(".")[-2] not in config.types
     ):
         raise click.BadParameter(
             "Expected filename '{}' to be of format '{{name}}.{{type}}', "
             "where '{{name}}' is an arbitrary slug and '{{type}}' is "
-            "one of: {}".format(filename, ", ".join(definitions))
+            "one of: {}".format(filename, ", ".join(config.types))
         )
 
     if config.directory:

--- a/src/towncrier/test/helpers.py
+++ b/src/towncrier/test/helpers.py
@@ -1,14 +1,17 @@
+from __future__ import annotations
+
 from functools import wraps
 from pathlib import Path
+from typing import Any, Callable
 
 from click.testing import CliRunner
 
 
-def read(filename):
+def read(filename: str | Path) -> str:
     return Path(filename).read_text()
 
 
-def write(path, contents):
+def write(path: str | Path, contents: str) -> None:
     """
     Create a file with given contents including any missing parent directories
     """
@@ -17,14 +20,14 @@ def write(path, contents):
     p.write_text(contents)
 
 
-def with_isolated_runner(fn):
+def with_isolated_runner(fn: Callable[..., Any]) -> Callable[..., Any]:
     """
     Run *fn* within an isolated filesystem and add the kwarg *runner* to its
     arguments.
     """
 
     @wraps(fn)
-    def test(*args, **kw):
+    def test(*args: Any, **kw: Any) -> Any:
         runner = CliRunner()
         with runner.isolated_filesystem():
             return fn(*args, runner=runner, **kw)
@@ -34,11 +37,11 @@ def with_isolated_runner(fn):
 
 def setup_simple_project(
     *,
-    config=None,
-    extra_config="",
-    pyproject_path="pyproject.toml",
-    mkdir_newsfragments=True,
-):
+    config: str | None = None,
+    extra_config: str = "",
+    pyproject_path: str = "pyproject.toml",
+    mkdir_newsfragments: bool = True,
+) -> None:
     if config is None:
         config = "[tool.towncrier]\n" 'package = "foo"\n' + extra_config
 

--- a/src/towncrier/test/helpers.py
+++ b/src/towncrier/test/helpers.py
@@ -1,0 +1,46 @@
+from functools import wraps
+from pathlib import Path
+
+from click.testing import CliRunner
+
+
+def read(filename):
+    return Path(filename).read_text()
+
+
+def write(path, contents):
+    """
+    Create a file with given contents including any missing parent directories
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True)
+    p.write_text(contents)
+
+
+def with_isolated_runner(fn):
+    """
+    Run *fn* within an isolated filesystem and add the kwarg *runner* to its
+    arguments.
+    """
+
+    @wraps(fn)
+    def test(*args, **kw):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            return fn(*args, runner=runner, **kw)
+
+    return test
+
+
+def setup_simple_project(
+    *, config=None, pyproject_path="pyproject.toml", mkdir_newsfragments=True
+):
+    if config is None:
+        config = "[tool.towncrier]\n" 'package = "foo"\n'
+
+    Path(pyproject_path).write_text(config)
+    Path("foo").mkdir()
+    Path("foo/__init__.py").write_text('__version__ = "1.2.3"\n')
+
+    if mkdir_newsfragments:
+        Path("foo/newsfragments").mkdir()

--- a/src/towncrier/test/helpers.py
+++ b/src/towncrier/test/helpers.py
@@ -13,7 +13,7 @@ def write(path, contents):
     Create a file with given contents including any missing parent directories
     """
     p = Path(path)
-    p.parent.mkdir(parents=True)
+    p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(contents)
 
 
@@ -33,10 +33,14 @@ def with_isolated_runner(fn):
 
 
 def setup_simple_project(
-    *, config=None, pyproject_path="pyproject.toml", mkdir_newsfragments=True
+    *,
+    config=None,
+    extra_config="",
+    pyproject_path="pyproject.toml",
+    mkdir_newsfragments=True,
 ):
     if config is None:
-        config = "[tool.towncrier]\n" 'package = "foo"\n'
+        config = "[tool.towncrier]\n" 'package = "foo"\n' + extra_config
 
     Path(pyproject_path).write_text(config)
     Path("foo").mkdir()

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -135,6 +135,8 @@ class TestCli(TestCase):
             result = runner.invoke(cli, ("--yes", "--dir", str(project_dir)))
 
             self.assertEqual([], list(Path(td).glob("*")))
+            # Staying in the temporary directory break cleanup on Windows.
+            os.chdir(project_dir)
 
         self.assertEqual(0, result.exit_code)
         self.assertTrue((project_dir / "NEWS.rst").exists())
@@ -153,8 +155,8 @@ class TestCli(TestCase):
         # Ensure our assetion below is meaningful.
         self.assertFalse((project_dir / "NEWS.rst").exists())
 
-        # Create a temporary directory, run Towncrier from there and assert
-        # it didn't litter into it.
+        # Create a temporary directory, move the config file there, run
+        # Towncrier from there, and assert it didn't litter into it.
         with tempfile.TemporaryDirectory() as td:
             os.chdir(td)
             (project_dir / "pyproject.toml").rename("pyproject.toml")
@@ -164,6 +166,8 @@ class TestCli(TestCase):
 
             # There's only pyproject.toml in this directory.
             self.assertEqual([Path(td) / "pyproject.toml"], list(Path(td).glob("*")))
+            # Staying in the temporary directory break cleanup on Windows.
+            os.chdir(project_dir)
 
         self.assertEqual(0, result.exit_code)
         self.assertTrue((project_dir / "NEWS.rst").exists())

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -5,7 +5,6 @@ import os
 import tempfile
 
 from datetime import date
-from functools import wraps
 from pathlib import Path
 from subprocess import call
 from textwrap import dedent
@@ -16,35 +15,7 @@ from twisted.trial.unittest import TestCase
 
 from .._shell import cli
 from ..build import _main
-
-
-def setup_simple_project():
-    with open("pyproject.toml", "w") as f:
-        f.write("[tool.towncrier]\n" 'package = "foo"\n')
-    os.mkdir("foo")
-    with open("foo/__init__.py", "w") as f:
-        f.write('__version__ = "1.2.3"\n')
-    os.mkdir("foo/newsfragments")
-
-
-def read_all(filename):
-    with open(filename) as f:
-        return f.read()
-
-
-def with_isolated_runner(fn):
-    """
-    Run *fn* within an isolated filesystem and add the kwarg *runner* to its
-    arguments.
-    """
-
-    @wraps(fn)
-    def test(*args, **kw):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            return fn(*args, runner=runner, **kw)
-
-    return test
+from .helpers import read, setup_simple_project, with_isolated_runner
 
 
 class TestCli(TestCase):
@@ -211,7 +182,7 @@ class TestCli(TestCase):
 
             result = runner.invoke(_main, ["--date", "01-01-2001"])
 
-            news = read_all("NEWS.rst")
+            news = read("NEWS.rst")
 
         self.assertEqual(0, result.exit_code)
         self.assertIn("No significant changes.\n", news)
@@ -720,8 +691,8 @@ class TestCli(TestCase):
             self.assertTrue(os.path.exists("7.9.0-notes.rst"), os.listdir("."))
 
             outputs = []
-            outputs.append(read_all("7.8.9-notes.rst"))
-            outputs.append(read_all("7.9.0-notes.rst"))
+            outputs.append(read("7.8.9-notes.rst"))
+            outputs.append(read("7.9.0-notes.rst"))
 
             self.assertEqual(
                 outputs[0],
@@ -830,7 +801,7 @@ class TestCli(TestCase):
             )
             self.assertTrue(os.path.exists("{version}-notes.rst"), os.listdir("."))
 
-            output = read_all("{version}-notes.rst")
+            output = read("{version}-notes.rst")
 
             self.assertEqual(
                 output,
@@ -896,7 +867,7 @@ class TestCli(TestCase):
             )
 
             self.assertEqual(0, result.exit_code, result.output)
-            output = read_all("NEWS.rst")
+            output = read("NEWS.rst")
 
         self.assertEqual(
             output,
@@ -1107,7 +1078,7 @@ Deprecations and Removals
 
             self.assertEqual(0, result.exit_code, result.output)
             self.assertTrue(os.path.exists("NEWS.rst"), os.listdir("."))
-            output = read_all("NEWS.rst")
+            output = read("NEWS.rst")
 
         expected_output = dedent(
             """\

--- a/src/towncrier/test/test_check.py
+++ b/src/towncrier/test/test_check.py
@@ -5,6 +5,7 @@ import os
 import os.path
 import sys
 
+from pathlib import Path
 from subprocess import PIPE, Popen, call
 
 from click.testing import CliRunner
@@ -13,22 +14,16 @@ from twisted.trial.unittest import TestCase
 from towncrier import check
 from towncrier.check import _main as towncrier_check
 
+from .helpers import setup_simple_project, write
+
 
 def create_project(pyproject_path="pyproject.toml", main_branch="main"):
     """
     Create the project files in the main branch that already has a
     news-fragment and then switch to a new in-work branch.
     """
-    with open(pyproject_path, "w") as f:
-        f.write("[tool.towncrier]\n" 'package = "foo"\n')
-    os.mkdir("foo")
-    with open("foo/__init__.py", "w") as f:
-        f.write('__version__ = "1.2.3"\n')
-    os.mkdir("foo/newsfragments")
-    fragment_path = "foo/newsfragments/123.feature"
-    with open(fragment_path, "w") as f:
-        f.write("Adds levitation")
-
+    setup_simple_project(pyproject_path=pyproject_path)
+    Path("foo/newsfragments/123.feature").write_text("Adds levitation")
     initial_commit(branch=main_branch)
     call(["git", "checkout", "-b", "otherbranch"])
 
@@ -41,18 +36,6 @@ def commit(message):
     """
     call(["git", "add", "."])
     call(["git", "commit", "-m", message])
-
-
-def write(path, contents):
-    """Create a file with given contents including any missing parent directories"""
-    dir = os.path.dirname(path)
-    if dir:
-        try:
-            os.makedirs(dir)
-        except OSError:  # pragma: no cover
-            pass
-    with open(path, "w") as f:
-        f.write(contents)
 
 
 def initial_commit(branch="main"):

--- a/src/towncrier/test/test_create.py
+++ b/src/towncrier/test/test_create.py
@@ -10,26 +10,7 @@ from click.testing import CliRunner
 from twisted.trial.unittest import TestCase
 
 from ..create import _main
-
-
-def setup_simple_project(config=None, mkdir=True):
-    if not config:
-        config = dedent(
-            """\
-            [tool.towncrier]
-            package = "foo"
-            """
-        )
-
-    with open("pyproject.toml", "w") as f:
-        f.write(config)
-
-    os.mkdir("foo")
-    with open("foo/__init__.py", "w") as f:
-        f.write('__version__ = "1.2.3"\n')
-
-    if mkdir:
-        os.mkdir("foo/newsfragments")
+from .helpers import setup_simple_project
 
 
 class TestCli(TestCase):
@@ -41,7 +22,7 @@ class TestCli(TestCase):
         runner = CliRunner()
 
         with runner.isolated_filesystem():
-            setup_simple_project(config, mkdir)
+            setup_simple_project(config=config, mkdir_newsfragments=mkdir)
 
             args = ["123.feature.rst"]
             if content is None:
@@ -95,7 +76,7 @@ class TestCli(TestCase):
             runner = CliRunner()
 
             with runner.isolated_filesystem():
-                setup_simple_project(config=None, mkdir=True)
+                setup_simple_project(config=None, mkdir_newsfragments=True)
                 result = runner.invoke(_main, ["123.feature.rst", "--edit"])
                 self.assertEqual([], os.listdir("foo/newsfragments"))
                 self.assertEqual(1, result.exit_code)
@@ -141,7 +122,7 @@ class TestCli(TestCase):
         )
 
         with runner.isolated_filesystem():
-            setup_simple_project(config, mkdir=False)
+            setup_simple_project(config=config, mkdir_newsfragments=False)
             os.mkdir("releasenotes")
 
             result = runner.invoke(_main, ["123.feature.rst"])

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -29,11 +29,11 @@ orphan_prefix = "~"
             )
 
         config = load_config(temp)
-        self.assertEqual(config["package"], "foobar")
-        self.assertEqual(config["package_dir"], ".")
-        self.assertEqual(config["filename"], "NEWS.rst")
-        self.assertEqual(config["underlines"], ["=", "-", "~"])
-        self.assertEqual(config["orphan_prefix"], "~")
+        self.assertEqual(config.package, "foobar")
+        self.assertEqual(config.package_dir, ".")
+        self.assertEqual(config.filename, "NEWS.rst")
+        self.assertEqual(config.underlines, ["=", "-", "~"])
+        self.assertEqual(config.orphan_prefix, "~")
 
     def test_missing(self):
         """
@@ -151,7 +151,7 @@ orphan_prefix = "~"
             )
 
         config = load_config(temp)
-        self.assertEqual(config["package"], "a")
+        self.assertEqual(config.package, "a")
 
     def test_missing_template(self):
         """
@@ -248,7 +248,7 @@ orphan_prefix = "~"
         config = self.load_config_from_string(
             toml_content,
         )
-        actual = config["types"]
+        actual = config.types
         self.assertDictEqual(expected, actual)
 
     def test_custom_types_as_tables(self):
@@ -297,7 +297,7 @@ orphan_prefix = "~"
         config = self.load_config_from_string(
             toml_content,
         )
-        actual = config["types"]
+        actual = config.types
         self.assertDictEqual(expected, actual)
 
     def load_config_from_string(self, toml_content):


### PR DESCRIPTION
# Description

It's time to say goodbye to the ungodly dictionary everywhere.

A few notes:

- I'm hereby proposing the `with_isolated_runner` decorator because the majority of our tests have the repetition of creation a `click.Runner` and then adding an unnecessary indentation level. I haven't applied it to other tests, but I think this would improve our test suit immensely.
- A few functions too a `definitions: list[str]` and used it as such, but definitions aren't a list, they're a dict and it worked by accident. I've renamed the argument to reflect what it actually is and just pass `definitions.keys()` into it.
- this PR is coming a day late, thanks for the merge conflicts #428 🤪

# Checklist
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
