### PR TITLE
Generate coverage reports using only GitHub Actions, without codecov.io

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-* @twisted/twisted-contributors

--- a/.github/scripts/pr_comment.js
+++ b/.github/scripts/pr_comment.js
@@ -33,7 +33,7 @@ module.exports = async ({github, context, process}) => {
             process.env.GITHUB_WORKSPACE + "/" + process.env.COMMENT_BODY, 'utf8');
         var comment_id = null
         var comment_marker = '\n' + process.env.COMMENT_MARKER
-        var comment_body =  body + comment_marker
+        var comment_body = body + comment_marker
 
         var comments = await octokit_rest.issues.listComments({
             owner: context.repo.owner,

--- a/.github/scripts/pr_comment.js
+++ b/.github/scripts/pr_comment.js
@@ -24,12 +24,23 @@ module.exports = async ({octokit_rest, context, process}) => {
     */
     var doAction = async function() {
 
+        fs = require('fs');
+        var body = fs.readFile(
+            process.env.GITHUB_WORKSPACE + "/" + process.env.COMMENT_BODY)
+
+        var comments = await octokit.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.event.number,
+          })
+        console.log(comments)
+
         await octokit_rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.event.number,
-            body: process.env.COMMENT_BODY,
-          });
+            body: body,
+          })
 
     }
 

--- a/.github/scripts/pr_comment.js
+++ b/.github/scripts/pr_comment.js
@@ -1,0 +1,42 @@
+/*
+Have a single comment on a PR, identified by a comment marker.
+
+Create a new comment if no comment already exists.
+Update the content of the existing comment.
+
+
+https://octokit.github.io/rest.js/v19
+*/
+module.exports = async ({octokit_rest, context, process}) => {
+    if (context.eventName != "pull_request") {
+        // Only PR are supported.
+        return
+    }
+
+    var sleep = function(second) {
+        return new Promise(resolve => setTimeout(resolve, second * 1000))
+    }
+
+    /*
+    Perform the actual logic.
+
+    This is wrapped so that we can retry on errors.
+    */
+    var doAction = async function() {
+
+        await octokit_rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.event.number,
+            body: process.env.COMMENT_BODY,
+          });
+
+    }
+
+    try {
+        await doAction()
+    } catch (e) {
+        await sleep(5)
+        await doAction()
+    }
+}

--- a/.github/scripts/pr_comment.js
+++ b/.github/scripts/pr_comment.js
@@ -33,7 +33,7 @@ module.exports = async ({github, context, process}) => {
             process.env.GITHUB_WORKSPACE + "/" + process.env.COMMENT_BODY, 'utf8');
         var comment_id = null
         var comment_marker = '\n' + process.env.COMMENT_MARKER
-        var comment_body = body + comment_marker
+        var comment_body =  body + comment_marker
 
         var comments = await octokit_rest.issues.listComments({
             owner: context.repo.owner,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,20 @@ jobs:
 
     - run: nox --python ${{ matrix.python.action }} -e ${{ matrix.task.nox }} -- --use-wheel dist/*.whl
 
+    - name: Store coverage file
+      uses: actions/upload-artifact@v3
+      with:
+        # We have a single artifact shared for each workflow run.
+        # in this way we should intefere with coverage reports from other PRs
+        # or previous runs for the same PR.
+        name: coverage-${{ github.run_id }}
+        # Is important to keep the unique names for the coverage files
+        # so that when uploaded to the same artifact, they don't overlap.
+        path: .coverage.*
+
     - name: Codecov
       run: |
+        coverage combine
         codecov -n "GitHub Actions - ${{ matrix.task.name}} - ${{ matrix.os.name }} ${{ matrix.python.name }}"
 
 
@@ -231,6 +243,37 @@ jobs:
       with:
         password: ${{ secrets.PYPI_TOKEN }}
         verbose: true
+
+  coverage-report:
+    name: Coverage report
+    runs-on: ubuntu-latest
+    needs:
+      # We are waiting only for test jobs.
+      - test-linux
+      - test-windows
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: python -m pip install --upgrade pip coverage[toml] diff_cover
+
+    - name: Download coverage reports
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage-${{ github.run_id }}
+        path: .
+
+    - name: Combine coverage
+      run: coverage combine
+
+    - name: Report coverage
+      run: coverage report
+
+    - name: Diff coverage
+      run: |
+        coverage xml
+        diff-cover --fail-under=100 coverage.xml
+
 
   # This is a meta-job to simplify PR CI enforcement configuration in GitHub.
   # Inside the GitHub config UI you only configure this job as required.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,7 @@ jobs:
       - test-windows
       - check
       - pypi-publish
+      - coverage-report
     steps:
       - name: Require all successes
         uses: re-actors/alls-green@3a2de129f0713010a71314c74e33c0e3ef90e696

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,8 +286,13 @@ jobs:
 
     - name: Report coverage
       run: |
+          coverage xml
           coverage report --no-skip-covered --show-missing
-          coverage report --show-missing > coverage-report.txt
+          # Wrap in
+          echo '```' > coverage-report.txt
+          coverage report --show-missing >> coverage-report.txt
+          diff-cover --compare-branch origin/trunk coverage.xml  >> coverage-report.txt
+          echo '```' >> coverage-report.txt
 
     # Use the generic JS script to call our custom script
     # for sending a comment to a PR.
@@ -301,10 +306,9 @@ jobs:
           // Only pass top level objects as GHA does dependecy injection.
           await script({github, context, process})
 
-    - name: Diff coverage
+    - name: Enforce diff coverage
       run: |
-        coverage xml
-        diff-cover --fail-under=100 --compare-branch origin/trunk coverage.xml
+          diff-cover --fail-under=100 --compare-branch origin/trunk coverage.xml
 
 
   # This is a meta-job to simplify PR CI enforcement configuration in GitHub.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,6 @@ jobs:
     - name: Store coverage file
       uses: actions/upload-artifact@v3
       with:
-        # We have a single artifact shared for each workflow run.
-        # in this way we should not interfere with coverage reports from other PRs
-        # or previous runs for the same PR.
         name: coverage
         # It is important to keep the unique names for the coverage files
         # so that when uploaded to the same artifact, they don't overlap.
@@ -153,9 +150,6 @@ jobs:
     - name: Store coverage file
       uses: actions/upload-artifact@v3
       with:
-        # We have a single artifact shared for each workflow run.
-        # in this way we should not interfere with coverage reports from other PRs
-        # or previous runs for the same PR.
         name: coverage
         # It is important to keep the unique names for the coverage files
         # so that when uploaded to the same artifact, they don't overlap.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,6 @@ jobs:
       - coverage-report
     steps:
       - name: Require all successes
-        uses: re-actors/alls-green@3a2de129f0713010a71314c74e33c0e3ef90e696
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,17 +283,16 @@ jobs:
       run: coverage combine
 
     - name: Report coverage
-      id: coverage-report
       run: |
           coverage report --no-skip-covered --show-missing
-          echo "coverage-report=$(coverage report --show-missing)" >> $GITHUB_OUTPUT
+          coverage report --show-missing > coverage-report.txt
 
     # Use the generic JS script to call our custom script
     # for sending a comment to a PR.
     - uses: actions/github-script@v3
       env:
         COMMENT_MARKER: coverage-report
-        COMMENT_BODY: ${{ needs.coverage-report.outputs.report }}
+        COMMENT_BODY: coverage-report.txt
       with:
         script: |
           const script = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr_comment.js`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
     # for sending a comment to a PR.
     - uses: actions/github-script@v3
       env:
-        COMMENT_MARKER: coverage-report
+        COMMENT_MARKER: "<!--- automatic-coverage-report -->"
         COMMENT_BODY: coverage-report.txt
       with:
         script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,8 +292,9 @@ jobs:
           # Wrap output in markdown verbatim text.
           echo '```' > coverage-report.txt
           coverage report --show-missing >> coverage-report.txt
-          diff-cover --compare-branch origin/trunk coverage.xml  >> coverage-report.txt
           echo '```' >> coverage-report.txt
+          diff-cover --markdown-report diff-cover.md  --compare-branch origin/trunk coverage.xml
+          cat diff-cover.md >> coverage-report.txt
 
     # Use the generic JS script to call our custom script
     # for sending a comment to a PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,8 +287,9 @@ jobs:
 
     - name: Diff coverage
       run: |
+        git fetch
         coverage xml
-        diff-cover --fail-under=100 coverage.xml
+        diff-cover --fail-under=100 --compare-branch origin/trunk  coverage.xml
 
 
   # This is a meta-job to simplify PR CI enforcement configuration in GitHub.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,10 +154,10 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         # We have a single artifact shared for each workflow run.
-        # in this way we should intefere with coverage reports from other PRs
+        # in this way we should not interfere with coverage reports from other PRs
         # or previous runs for the same PR.
         name: coverage-${{ github.run_id }}
-        # Is important to keep the unique names for the coverage files
+        # It is important to keep the unique names for the coverage files
         # so that when uploaded to the same artifact, they don't overlap.
         path: .coverage*
 
@@ -271,7 +271,9 @@ jobs:
         fetch-depth: 0
 
     - name: Install dependencies
-      run: python -m pip install --upgrade pip coverage[toml] diff_cover
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade coverage[toml] diff_cover
 
     - name: Download coverage reports
       uses: actions/download-artifact@v3
@@ -301,7 +303,6 @@ jobs:
 
     - name: Diff coverage
       run: |
-        git fetch
         coverage xml
         diff-cover --fail-under=100 --compare-branch origin/trunk coverage.xml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,8 @@ jobs:
 
     # Use the generic JS script to call our custom script
     # for sending a comment to a PR.
-    - uses: actions/github-script@v3
+    - name: Send coverage comment to PR
+      uses: actions/github-script@v3
       env:
         COMMENT_MARKER: "<!--- automatic-coverage-report -->"
         COMMENT_BODY: coverage-report.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,10 +100,10 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         # We have a single artifact shared for each workflow run.
-        # in this way we should intefere with coverage reports from other PRs
+        # in this way we should not interfere with coverage reports from other PRs
         # or previous runs for the same PR.
         name: coverage-${{ github.run_id }}
-        # Is important to keep the unique names for the coverage files
+        # It is important to keep the unique names for the coverage files
         # so that when uploaded to the same artifact, they don't overlap.
         path: .coverage*
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     tags: [ "**" ]
   pull_request:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -255,6 +258,10 @@ jobs:
   coverage-report:
     name: Coverage report
     runs-on: ubuntu-latest
+    permissions:
+      # Even we send a comment to a PR, we use the issues API.
+      # Issues and PR share the same comment API.
+      issues: write
     needs:
       # We are waiting only for test jobs.
       - test-linux
@@ -282,7 +289,7 @@ jobs:
       run: |
           coverage xml
           coverage report --no-skip-covered --show-missing
-          # Wrap in
+          # Wrap output in markdown verbatim text.
           echo '```' > coverage-report.txt
           coverage report --show-missing >> coverage-report.txt
           diff-cover --compare-branch origin/trunk coverage.xml  >> coverage-report.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,13 +283,28 @@ jobs:
       run: coverage combine
 
     - name: Report coverage
-      run: coverage report --no-skip-covered --show-missing
+      id: coverage-report
+      run: |
+          coverage report --no-skip-covered --show-missing
+          echo "coverage-report=$(coverage report --show-missing)" >> $GITHUB_OUTPUT
+
+    # Use the generic JS script to call our custom script
+    # for sending a comment to a PR.
+    - uses: actions/github-script@v3
+      env:
+        COMMENT_MARKER: coverage-report
+        COMMENT_BODY: ${{ needs.coverage-report.outputs.report }}
+      with:
+        script: |
+          const script = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr_comment.js`)
+          // Only pass top level objects as GHA does dependecy injection.
+          await script({github, context, process})
 
     - name: Diff coverage
       run: |
         git fetch
         coverage xml
-        diff-cover --fail-under=100 --compare-branch origin/trunk  coverage.xml
+        diff-cover --fail-under=100 --compare-branch origin/trunk coverage.xml
 
 
   # This is a meta-job to simplify PR CI enforcement configuration in GitHub.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         # We have a single artifact shared for each workflow run.
         # in this way we should not interfere with coverage reports from other PRs
         # or previous runs for the same PR.
-        name: coverage-${{ github.run_id }}
+        name: coverage
         # It is important to keep the unique names for the coverage files
         # so that when uploaded to the same artifact, they don't overlap.
         path: .coverage*
@@ -156,7 +156,7 @@ jobs:
         # We have a single artifact shared for each workflow run.
         # in this way we should not interfere with coverage reports from other PRs
         # or previous runs for the same PR.
-        name: coverage-${{ github.run_id }}
+        name: coverage
         # It is important to keep the unique names for the coverage files
         # so that when uploaded to the same artifact, they don't overlap.
         path: .coverage*
@@ -278,7 +278,7 @@ jobs:
     - name: Download coverage reports
       uses: actions/download-artifact@v3
       with:
-        name: coverage-${{ github.run_id }}
+        name: coverage
         path: .
 
     - name: Combine coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,11 @@ jobs:
         name: coverage-${{ github.run_id }}
         # Is important to keep the unique names for the coverage files
         # so that when uploaded to the same artifact, they don't overlap.
-        path: .coverage.*
+        path: .coverage*
 
     - name: Codecov
       run: |
+        ls -al .coverage*
         coverage combine
         codecov -n "GitHub Actions - ${{ matrix.task.name}} - ${{ matrix.os.name }} ${{ matrix.python.name }}"
 
@@ -149,8 +150,21 @@ jobs:
 
     - run: nox --python ${{ matrix.python.action }} -e ${{ matrix.task.nox }} -- --use-wheel dist/*.whl
 
+    - name: Store coverage file
+      uses: actions/upload-artifact@v3
+      with:
+        # We have a single artifact shared for each workflow run.
+        # in this way we should intefere with coverage reports from other PRs
+        # or previous runs for the same PR.
+        name: coverage-${{ github.run_id }}
+        # Is important to keep the unique names for the coverage files
+        # so that when uploaded to the same artifact, they don't overlap.
+        path: .coverage*
+
     - name: Codecov
       run: |
+        ls -al .coverage*
+        coverage combine
         codecov -n "GitHub Actions - ${{ matrix.task.name}} - ${{ matrix.os.name }} ${{ matrix.python.name }}"
 
   check:
@@ -253,6 +267,8 @@ jobs:
       - test-windows
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Install dependencies
       run: python -m pip install --upgrade pip coverage[toml] diff_cover
@@ -267,7 +283,7 @@ jobs:
       run: coverage combine
 
     - name: Report coverage
-      run: coverage report
+      run: coverage report --no-skip-covered --show-missing
 
     - name: Diff coverage
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 venv/
 htmlcov/
 .coverage
+coverage.xml
 *~
 *.lock
 apidocs/

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,7 +36,7 @@ def tests(session: nox.Session) -> None:
     session.run("coverage", "run", "--module", "twisted.trial", *posargs)
 
     if os.environ.get("CI") != "true":
-        # When running the test localy, show the coverage report.
+        # When running the test locally, show the coverage report.
         session.notify("coverage_report")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,9 +36,8 @@ def tests(session: nox.Session) -> None:
     session.run("coverage", "run", "--module", "twisted.trial", *posargs)
 
     if os.environ.get("CI") != "true":
+        # When running the test localy, show the coverage report.
         session.notify("coverage_report")
-    else:
-        session.run("coverage", "combine")
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,5 +107,4 @@ exclude_lines = [
 ]
 omit = [
     "src/towncrier/__main__.py",
-    "src/towncrier/test/*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ source = ["towncrier"]
 source = [
     "src",
     "*.nox/*/site-packages",
+    # required until coverage 6.6.0 is used: https://github.com/nedbat/coveragepy/issues/991
     "*.nox\\*\\*\\site-packages"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,11 @@ branch = true
 source = ["towncrier"]
 
 [tool.coverage.paths]
-source = ["src", ".nox/*/site-packages"]
+source = [
+    "src",
+    "*.nox/*/site-packages",
+    "*.nox\\*\\*\\site-packages"
+]
 
 [tool.coverage.report]
 show_missing = true


### PR DESCRIPTION
# Description

Fixes #410

This tries to generate coverage reports only via GitHub Actions...so that we don't have to depend on codecov.io


# Drive-by

I have removed the codeowner as I don't think it helps.
