### PR TITLE
Update links in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,5 +41,5 @@ Project Links
 
 - **PyPI**: https://pypi.org/project/towncrier/
 - **Documentation**: https://towncrier.readthedocs.io/
-- **News**: https://github.com/twisted/towncrier/blob/trunk/NEWS.rst
+- **Release Notes**: https://github.com/twisted/towncrier/blob/trunk/NEWS.rst
 - **License**: `MIT <https://github.com/twisted/towncrier/blob/trunk/LICENSE>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ Development
 
    contributing
    release
+   GitHub Repository <https://github.com/twisted/towncrier>
 
 .. include:: ../README.rst
    :start-after: .. links

--- a/src/towncrier/newsfragments/459.misc
+++ b/src/towncrier/newsfragments/459.misc
@@ -1,0 +1,2 @@
+Added a link to the GitHub repository on the landing page of the
+documentation, and renamed the link for the release notes.


### PR DESCRIPTION
# Description

From landing page right now, it's hard to navigate to the GitHub repository.  I also found it hard to find the release notes since I was looking for something like "Changes", "Changelog", or "Release Notes".  

This PR makes the following changes to the front page of the docs, hopefully to make it easier to find what's :

 - Added a link to the GitHub repository
 - Renamed the link from "News" to "Release Notes"

Also, the maintainers should please feel free to edit this directly.  

Thanks! 

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [ ] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [x] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
