### PR TITLE
Interactive create

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -74,8 +74,9 @@ In the above example, it will generate ``123.bugfix.1.rst`` if ``123.bugfix.rst`
 
 .. option:: --edit
 
-   Create file and start `$EDITOR` to edit it right away.`
+   Create file and start ``$EDITOR`` to edit the news fragment right away.
 
+If you don't provide a file name, ``towncrier`` will prompt you for one, and unless you provided content, it'll also open an editor for you to write the news fragment.
 
 ``towncrier check``
 -------------------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -74,7 +74,9 @@ In the above example, it will generate ``123.bugfix.1.rst`` if ``123.bugfix.rst`
 
 .. option:: --edit
 
-   Create file and start `$EDITOR` to edit it right away.`
+   Create file and start ``$EDITOR`` to edit the news fragment right away.
+
+If you don't provide a file name, ``towncrier`` will prompt you for one, and unless you provided content, it'll also open an editor for you to write the news fragment.
 
 
 ``towncrier check``

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -129,6 +129,7 @@ All Options
    wrap = false  # Wrap text to 79 characters
    all_bullets = true  # make all fragments bullet points
    orphan_prefix = "+"   # Prefix for orphan news fragment files, set to "" to disable.
+   create_eof_newline = true  # Ensure the content of a news fragment file created with ``towncrier create`` ends with an empty line.
    create_add_extension = true  # Add the ``filename`` option extension to news fragment files created with ``towncrier create`` (if extension not explicitly provided).
 
 If ``single_file`` is set to ``true`` or unspecified, all changes will be written to a single fixed newsfile, whose name is literally fixed as the ``filename`` option.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -129,6 +129,7 @@ All Options
    wrap = false  # Wrap text to 79 characters
    all_bullets = true  # make all fragments bullet points
    orphan_prefix = "+"   # Prefix for orphan news fragment files, set to "" to disable.
+   create_add_extension = true  # Add the ``filename`` option extension to news fragment files created with ``towncrier create`` (if extension not explicitly provided).
 
 If ``single_file`` is set to ``true`` or unspecified, all changes will be written to a single fixed newsfile, whose name is literally fixed as the ``filename`` option.
 In each run of ``towncrier build``, content of new changes will append at the top of old content, and after ``start_string`` if the ``start_string`` already appears in the newsfile.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -117,6 +117,12 @@ Top level keys
 
     ``"+"`` by default.
 
+``create_add_extension``
+    Add the ``filename`` option's extension to news fragment files created with ``towncrier create`` (if extension not explicitly provided).
+
+    ``true`` by default.
+
+
 Extra top level keys for Python projects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -117,6 +117,11 @@ Top level keys
 
     ``"+"`` by default.
 
+``create_eof_newline``
+    Ensure the content of a news fragment file created with ``towncrier create`` ends with an empty line.
+
+    ``true`` by default.
+
 ``create_add_extension``
     Add the ``filename`` option's extension to news fragment files created with ``towncrier create`` (if extension not explicitly provided).
 

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -48,6 +48,7 @@ class Config:
     wrap: bool
     all_bullets: bool
     orphan_prefix: str
+    create_add_extension: bool = True
 
 
 class ConfigError(Exception):
@@ -181,4 +182,5 @@ def parse_toml(base_path: str, config: Mapping[str, Any]) -> Config:
         wrap=wrap,
         all_bullets=all_bullets,
         orphan_prefix=config.get("orphan_prefix", "+"),
+        create_add_extension=config.get("create_add_extension", True),
     )

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -58,6 +58,7 @@ class Config:
     wrap: bool = False
     all_bullets: bool = True
     orphan_prefix: str = "+"
+    create_add_extension: bool = True
 
 
 class ConfigError(Exception):

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import os
 import sys
-
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Mapping
@@ -13,7 +12,6 @@ from typing import TYPE_CHECKING, Any, Mapping
 import pkg_resources
 
 from .._settings import fragment_types as ft
-
 
 if TYPE_CHECKING:
     # We only use Literal for type-checking and Mypy always brings its own
@@ -48,6 +46,7 @@ class Config:
     wrap: bool
     all_bullets: bool
     orphan_prefix: str
+    create_eof_newline: bool = True
     create_add_extension: bool = True
 
 
@@ -182,5 +181,6 @@ def parse_toml(base_path: str, config: Mapping[str, Any]) -> Config:
         wrap=wrap,
         all_bullets=all_bullets,
         orphan_prefix=config.get("orphan_prefix", "+"),
+        create_eof_newline=config.get("create_eof_newline", True),
         create_add_extension=config.get("create_add_extension", True),
     )

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import sys
+
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Mapping
@@ -12,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Mapping
 import pkg_resources
 
 from .._settings import fragment_types as ft
+
 
 if TYPE_CHECKING:
     # We only use Literal for type-checking and Mypy always brings its own

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -58,6 +58,7 @@ class Config:
     wrap: bool = False
     all_bullets: bool = True
     orphan_prefix: str = "+"
+    create_eof_newline: bool = True
     create_add_extension: bool = True
 
 

--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -45,6 +45,11 @@ DEFAULT_CONTENT = "Add your info here"
     default=DEFAULT_CONTENT,
     help="Sets the content of the new fragment.",
 )
+@click.option(
+    "--eof-newline/--no-eof-newline",
+    default=None,
+    help="Ensure the content ends with an empty line.",
+)
 @click.argument("filename", default="")
 def _main(
     ctx: click.Context,
@@ -53,6 +58,7 @@ def _main(
     filename: str,
     edit: bool | None,
     content: str,
+    eof_newline: bool | None,
 ) -> None:
     """
     Create a new news fragment.
@@ -70,7 +76,7 @@ def _main(
     * .removal - a deprecation or removal of public API,
     * .misc - a ticket has been closed, but it is not of interest to users.
     """
-    __main(ctx, directory, config, filename, edit, content)
+    __main(ctx, directory, config, filename, edit, content, eof_newline)
 
 
 def __main(
@@ -80,11 +86,14 @@ def __main(
     filename: str,
     edit: bool | None,
     content: str,
+    eof_newline: bool | None,
 ) -> None:
     """
     The main entry point.
     """
     base_directory, config = load_config_from_options(directory, config_path)
+    if eof_newline is None:
+        eof_newline = config.create_eof_newline
 
     filename_ext = ""
     if config.create_add_extension:
@@ -165,6 +174,8 @@ def __main(
 
     with open(segment_file, "w") as f:
         f.write(content)
+        if eof_newline and content and not content.endswith("\n"):
+            f.write("\n")
 
     click.echo(f"Created news fragment at {segment_file}")
 

--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -14,6 +14,9 @@ import click
 from ._settings import config_option_help, load_config_from_options
 
 
+DEFAULT_CONTENT = "Add your info here"
+
+
 @click.command(name="create")
 @click.pass_context
 @click.option(
@@ -32,30 +35,32 @@ from ._settings import config_option_help, load_config_from_options
 )
 @click.option(
     "--edit/--no-edit",
-    default=False,
+    default=None,
     help="Open an editor for writing the newsfragment content.",
-)  # TODO: default should be true
+)
 @click.option(
     "-c",
     "--content",
     type=str,
-    default="Add your info here",
+    default=DEFAULT_CONTENT,
     help="Sets the content of the new fragment.",
 )
-@click.argument("filename")
+@click.argument("filename", default="")
 def _main(
     ctx: click.Context,
     directory: str | None,
     config: str | None,
     filename: str,
-    edit: bool,
+    edit: bool | None,
     content: str,
 ) -> None:
     """
     Create a new news fragment.
 
-    Create a new news fragment called FILENAME or pass the full path for a file.
-    Towncrier has a few standard types of news fragments, signified by the file extension.
+    If FILENAME is not provided, you'll be prompted to create it.
+
+    Towncrier has a few standard types of news fragments, signified by the file
+    extension.
 
     \b
     These are:
@@ -73,13 +78,29 @@ def __main(
     directory: str | None,
     config_path: str | None,
     filename: str,
-    edit: bool,
+    edit: bool | None,
     content: str,
 ) -> None:
     """
     The main entry point.
     """
     base_directory, config = load_config_from_options(directory, config_path)
+
+    filename_ext = ""
+    if config.create_add_extension:
+        ext = os.path.splitext(config.filename)[1]
+        if ext.lower() in (".rst", ".md"):
+            filename_ext = ext
+
+    if not filename:
+        issue = click.prompt("Issue number")
+        fragment_type = click.prompt(
+            "Fragment type",
+            type=click.Choice(config.types),
+        )
+        filename = f"{issue}.{fragment_type}"
+        if edit is None and content == DEFAULT_CONTENT:
+            edit = True
 
     file_dir, file_basename = os.path.split(filename)
     if config.orphan_prefix and file_basename.startswith(f"{config.orphan_prefix}."):
@@ -91,15 +112,18 @@ def __main(
                 f"{file_basename[len(config.orphan_prefix):]}"
             ),
         )
-    if len(filename.split(".")) < 2 or (
-        filename.split(".")[-1] not in config.types
-        and filename.split(".")[-2] not in config.types
+    filename_parts = filename.split(".")
+    if len(filename_parts) < 2 or (
+        filename_parts[-1] not in config.types
+        and filename_parts[-2] not in config.types
     ):
         raise click.BadParameter(
             "Expected filename '{}' to be of format '{{name}}.{{type}}', "
             "where '{{name}}' is an arbitrary slug and '{{type}}' is "
             "one of: {}".format(filename, ", ".join(config.types))
         )
+    if filename_parts[-1] in config.types and filename_ext:
+        filename += filename_ext
 
     if config.directory:
         fragments_directory = os.path.abspath(
@@ -132,11 +156,12 @@ def __main(
         )
 
     if edit:
-        edited_content = _get_news_content_from_user(content)
-        if edited_content is None:
-            click.echo("Abort creating news fragment.")
+        if content == DEFAULT_CONTENT:
+            content = ""
+        content = _get_news_content_from_user(content)
+        if not content:
+            click.echo("Aborted creating news fragment due to empty message.")
             ctx.exit(1)
-        content = edited_content
 
     with open(segment_file, "w") as f:
         f.write(content)
@@ -144,19 +169,19 @@ def __main(
     click.echo(f"Created news fragment at {segment_file}")
 
 
-def _get_news_content_from_user(message: str) -> str | None:
-    initial_content = (
-        "# Please write your news content. When finished, save the file.\n"
-        "# In order to abort, exit without saving.\n"
-        '# Lines starting with "#" are ignored.\n'
-    )
-    initial_content += f"\n{message}\n"
+def _get_news_content_from_user(message: str) -> str:
+    initial_content = """
+# Please write your news content. Lines starting with '#' will be ignored, and
+# an empty message aborts.
+"""
+    if message:
+        initial_content = f"{message}\n{initial_content}"
     content = click.edit(initial_content)
     if content is None:
-        return None
+        return message
     all_lines = content.split("\n")
     lines = [line.rstrip() for line in all_lines if not line.lstrip().startswith("#")]
-    return "\n".join(lines)
+    return "\n".join(lines).strip()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -102,7 +102,11 @@ def __main(
             filename_ext = ext
 
     if not filename:
-        issue = click.prompt("Issue number")
+        prompt = "Issue number"
+        # Add info about adding orphan if config is set.
+        if config.orphan_prefix:
+            prompt += f" (`{config.orphan_prefix}` if none)"
+        issue = click.prompt(prompt)
         fragment_type = click.prompt(
             "Fragment type",
             type=click.Choice(list(config.types)),

--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -105,7 +105,7 @@ def __main(
         issue = click.prompt("Issue number")
         fragment_type = click.prompt(
             "Fragment type",
-            type=click.Choice(config.types),
+            type=click.Choice(list(config.types)),
         )
         filename = f"{issue}.{fragment_type}"
         if edit is None and content == DEFAULT_CONTENT:

--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -45,11 +45,6 @@ DEFAULT_CONTENT = "Add your info here"
     default=DEFAULT_CONTENT,
     help="Sets the content of the new fragment.",
 )
-@click.option(
-    "--eof-newline/--no-eof-newline",
-    default=None,
-    help="Ensure the content ends with an empty line.",
-)
 @click.argument("filename", default="")
 def _main(
     ctx: click.Context,
@@ -58,7 +53,6 @@ def _main(
     filename: str,
     edit: bool | None,
     content: str,
-    eof_newline: bool | None,
 ) -> None:
     """
     Create a new news fragment.
@@ -76,7 +70,7 @@ def _main(
     * .removal - a deprecation or removal of public API,
     * .misc - a ticket has been closed, but it is not of interest to users.
     """
-    __main(ctx, directory, config, filename, edit, content, eof_newline)
+    __main(ctx, directory, config, filename, edit, content)
 
 
 def __main(
@@ -86,14 +80,11 @@ def __main(
     filename: str,
     edit: bool | None,
     content: str,
-    eof_newline: bool | None,
 ) -> None:
     """
     The main entry point.
     """
     base_directory, config = load_config_from_options(directory, config_path)
-    if eof_newline is None:
-        eof_newline = config.create_eof_newline
 
     filename_ext = ""
     if config.create_add_extension:
@@ -178,7 +169,7 @@ def __main(
 
     with open(segment_file, "w") as f:
         f.write(content)
-        if eof_newline and content and not content.endswith("\n"):
+        if config.create_eof_newline and content and not content.endswith("\n"):
             f.write("\n")
 
     click.echo(f"Created news fragment at {segment_file}")

--- a/src/towncrier/newsfragments/482.feature.rst
+++ b/src/towncrier/newsfragments/482.feature.rst
@@ -1,0 +1,1 @@
+If no filename is given when doing ``towncrier`` create, interactively ask for the issue number and fragment type (and then launch an interactive editor for the fragment content).

--- a/src/towncrier/newsfragments/482.feature.rst
+++ b/src/towncrier/newsfragments/482.feature.rst
@@ -1,1 +1,5 @@
 If no filename is given when doing ``towncrier`` create, interactively ask for the issue number and fragment type (and then launch an interactive editor for the fragment content).
+
+Now by default, when creating a fragment it will be appended with the ``filename`` option's extension (unless an extension is explicitly provided). For example, ``towncrier create 123.feature`` will create ``news/123.feature.rst``. This can be changed in configuration file by setting `add_extension = false`.
+
+A new line is now added by default to the end of the fragment contents. This can be reverted in the configuration file by setting `add_newline = false` or explicitly set with the ``create`` command line flags ``--eof-newline/--no-eof-newline``.

--- a/src/towncrier/newsfragments/482.feature.rst
+++ b/src/towncrier/newsfragments/482.feature.rst
@@ -2,4 +2,4 @@ If no filename is given when doing ``towncrier`` create, interactively ask for t
 
 Now by default, when creating a fragment it will be appended with the ``filename`` option's extension (unless an extension is explicitly provided). For example, ``towncrier create 123.feature`` will create ``news/123.feature.rst``. This can be changed in configuration file by setting `add_extension = false`.
 
-A new line is now added by default to the end of the fragment contents. This can be reverted in the configuration file by setting `add_newline = false` or explicitly set with the ``create`` command line flags ``--eof-newline/--no-eof-newline``.
+A new line is now added by default to the end of the fragment contents. This can be reverted in the configuration file by setting `add_newline = false`.

--- a/src/towncrier/test/test_create.py
+++ b/src/towncrier/test/test_create.py
@@ -491,4 +491,4 @@ Created news fragment at {expected}
         )
 
         self.assertEqual(0, result.exit_code)
-        self.assertTrue(Path("foo/changelog.d/123.feature").exists())
+        self.assertTrue(Path("foo/changelog.d/123.feature.rst").exists())

--- a/src/towncrier/test/test_create.py
+++ b/src/towncrier/test/test_create.py
@@ -213,9 +213,15 @@ class TestCli(TestCase):
         self.assertEqual(fragments, ["123.feature.md"])
 
     @with_isolated_runner
-    def test_odd_filename_extension(self, runner: CliRunner):
-        """Ensure changelog filename extension is not used if not .rst or .md"""
-        setup_simple_project(extra_config='filename = "the.changes"')
+    def test_no_filename_extension(self, runner: CliRunner):
+        """
+        When the NEWS filename has no extension, new fragments are will not have an
+        extension added.
+        """
+        # The name of the file where towncrier will generate
+        # the final release notes is named `RELEASE_NOTES`
+        # for this test (with no file extension).
+        setup_simple_project(extra_config='filename = "RELEASE_NOTES"')
         frag_path = Path("foo", "newsfragments")
 
         result = runner.invoke(_main, ["123.feature"])
@@ -247,7 +253,10 @@ class TestCli(TestCase):
 
     @with_isolated_runner
     def test_file_exists_no_ext(self, runner: CliRunner):
-        """Ensure we don't overwrite existing files."""
+        """
+        Ensure we don't overwrite existing files with when not adding filename
+        extensions.
+        """
 
         setup_simple_project(extra_config="create_add_extension = false")
         frag_path = Path("foo", "newsfragments")

--- a/src/towncrier/test/test_create.py
+++ b/src/towncrier/test/test_create.py
@@ -117,19 +117,6 @@ class TestCli(TestCase):
             eof_newline=False,
         )
 
-    def test_content_no_eof_newline_arg(self):
-        """
-        When creating a new fragment the content can be passed as a command line
-        argument. The text editor is not invoked, and no eof newline is added if the
-        --no-eof-newline argument is passed.
-        """
-        content_line = "This is a content"
-        self._test_success(
-            content=[content_line],
-            additional_args=["-c", content_line, "--no-eof-newline"],
-            eof_newline=False,
-        )
-
     def test_message_and_edit(self):
         """
         When creating a new message, a initial content can be passed via

--- a/src/towncrier/test/test_create.py
+++ b/src/towncrier/test/test_create.py
@@ -3,6 +3,7 @@
 
 import os
 import string
+
 from pathlib import Path
 from textwrap import dedent
 from unittest import mock
@@ -18,7 +19,12 @@ class TestCli(TestCase):
     maxDiff = None
 
     def _test_success(
-        self, content=None, config=None, mkdir=True, additional_args=None
+        self,
+        content=None,
+        config=None,
+        mkdir=True,
+        additional_args=None,
+        eof_newline=True,
     ):
         runner = CliRunner()
 
@@ -34,6 +40,8 @@ class TestCli(TestCase):
 
             self.assertEqual(["123.feature.rst"], os.listdir("foo/newsfragments"))
 
+            if eof_newline:
+                content.append("")
             with open("foo/newsfragments/123.feature.rst") as fh:
                 self.assertEqual("\n".join(content), fh.read())
 
@@ -87,6 +95,40 @@ class TestCli(TestCase):
         """
         content_line = "This is a content"
         self._test_success(content=[content_line], additional_args=["-c", content_line])
+
+    def test_content_without_eof_newline(self):
+        """
+        When creating a new fragment the content can be passed as a command line
+        argument. The text editor is not invoked, and no eof newline is added if the
+        config option is set.
+        """
+        config = dedent(
+            """\
+            [tool.towncrier]
+            package = "foo"
+            create_eof_newline = false
+            """
+        )
+        content_line = "This is a content"
+        self._test_success(
+            content=[content_line],
+            additional_args=["-c", content_line],
+            config=config,
+            eof_newline=False,
+        )
+
+    def test_content_no_eof_newline_arg(self):
+        """
+        When creating a new fragment the content can be passed as a command line
+        argument. The text editor is not invoked, and no eof newline is added if the
+        --no-eof-newline argument is passed.
+        """
+        content_line = "This is a content"
+        self._test_success(
+            content=[content_line],
+            additional_args=["-c", content_line, "--no-eof-newline"],
+            eof_newline=False,
+        )
 
     def test_message_and_edit(self):
         """
@@ -228,8 +270,8 @@ Fragment type (feature, bugfix, doc, removal, misc): feature
 Created news fragment at {expected}
 """,
         )
-        with open(expected, "r") as f:
-            self.assertEqual(f.read(), "Edited content")
+        with open(expected) as f:
+            self.assertEqual(f.read(), "Edited content\n")
 
     @with_isolated_runner
     def test_without_filename_with_message(self, runner: CliRunner):
@@ -251,8 +293,8 @@ Fragment type (feature, bugfix, doc, removal, misc): feature
 Created news fragment at {expected}
 """,
         )
-        with open(expected, "r") as f:
-            self.assertEqual(f.read(), "Fixed this")
+        with open(expected) as f:
+            self.assertEqual(f.read(), "Fixed this\n")
 
     @with_isolated_runner
     def test_create_orphan_fragment(self, runner: CliRunner):

--- a/src/towncrier/test/test_create.py
+++ b/src/towncrier/test/test_create.py
@@ -187,6 +187,45 @@ class TestCli(TestCase):
         )
 
     @with_isolated_runner
+    def test_custom_extension(self, runner: CliRunner):
+        """Ensure we can still create fragments with custom extensions."""
+        setup_simple_project()
+        frag_path = Path("foo", "newsfragments")
+
+        result = runner.invoke(_main, ["123.feature.txt"])
+        self.assertEqual(result.exit_code, 0, result.output)
+
+        fragments = [f.name for f in frag_path.iterdir()]
+        # No '.rst' extension added.
+        self.assertEqual(fragments, ["123.feature.txt"])
+
+    @with_isolated_runner
+    def test_md_filename_extension(self, runner: CliRunner):
+        """Ensure changelog filename extension is used if .md"""
+        setup_simple_project(extra_config='filename = "changes.md"')
+        frag_path = Path("foo", "newsfragments")
+
+        result = runner.invoke(_main, ["123.feature"])
+        self.assertEqual(result.exit_code, 0, result.output)
+
+        fragments = [f.name for f in frag_path.iterdir()]
+        # No '.rst' extension added.
+        self.assertEqual(fragments, ["123.feature.md"])
+
+    @with_isolated_runner
+    def test_odd_filename_extension(self, runner: CliRunner):
+        """Ensure changelog filename extension is not used if not .rst or .md"""
+        setup_simple_project(extra_config='filename = "the.changes"')
+        frag_path = Path("foo", "newsfragments")
+
+        result = runner.invoke(_main, ["123.feature"])
+        self.assertEqual(result.exit_code, 0, result.output)
+
+        fragments = [f.name for f in frag_path.iterdir()]
+        # No '.rst' extension added.
+        self.assertEqual(fragments, ["123.feature"])
+
+    @with_isolated_runner
     def test_file_exists(self, runner: CliRunner):
         """Ensure we don't overwrite existing files."""
         setup_simple_project()

--- a/src/towncrier/test/test_create.py
+++ b/src/towncrier/test/test_create.py
@@ -3,6 +3,7 @@
 
 import os
 import string
+
 from pathlib import Path
 from textwrap import dedent
 from unittest import mock
@@ -269,7 +270,7 @@ Fragment type (feature, bugfix, doc, removal, misc): feature
 Created news fragment at {expected}
 """,
         )
-        with open(expected, "r") as f:
+        with open(expected) as f:
             self.assertEqual(f.read(), "Edited content\n")
 
     @with_isolated_runner
@@ -292,7 +293,7 @@ Fragment type (feature, bugfix, doc, removal, misc): feature
 Created news fragment at {expected}
 """,
         )
-        with open(expected, "r") as f:
+        with open(expected) as f:
             self.assertEqual(f.read(), "Fixed this\n")
 
     @with_isolated_runner


### PR DESCRIPTION
# Description
If no filename is given when doing `towncrier create`, interactively ask for the issue number and fragment type (and then launch an interactive editor for the newsfragment content).

```console
$ towncrier create
Issue number (`+` for none): 482
Fragment type (feature, bugfix, doc, removal, misc): feature
($EDITOR opened here)
Created news fragment at /home/chris/dev/towncrier/src/towncrier/newsfragments/482.feature.rst
```

## Reworded interactive edit comment
The comment given to the editor has been reworded to use the similar format as a git commit interactive edit, with the empty space above rather than below:
```
█
# Please write your news content. Lines starting with '#' will be ignored, and
# an empty message aborts.
```

## Default news fragment filename extension
If the file extension of the `filename` configuration setting ends in `.rst` or `.md`, `towncrier create` will append this extension to newsfragments it creates (if the filename didn't provide an explicit extension).
```console
$ towncrier create 1.feature
Created news fragment at /home/chris/dev/towncrier/src/towncrier/newsfragments/1.feature.rst
$ towncrier create 2.feature.txt
Created news fragment at /home/chris/dev/towncrier/src/towncrier/newsfragments/2.feature.txt
```
This is configurable with a new `create_add_extension` setting (`true` by default).

## Add an empty line to the end of news fragments
An empty line is now added to the end of news fragment content, whether entered by the command line option or interactively.
This is configurable with a new `create_eof_newline` setting (`true` by default).

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [x] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
