### PR TITLE
Default markdown template

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -34,22 +34,24 @@ Top level keys
 ~~~~~~~~~~~~~~
 
 ``name``
-    The name of your project. If empty and the ``package`` key is provided, the name will be automatically determined.
+    The name of your project.
+
+    For Python projects that provide a ``package`` key, if left empty then the name will be automatically determined.
 
     ``""`` by default.
 
 ``version``
     The version of your project.
 
-    Python projects that provide the ``package`` key can have the version to be automatically determined from a ``__version__`` variable in the package's module (or the version if the package is installed).
+    Python projects that provide the ``package`` key can have the version to be automatically determined from a ``__version__`` variable in the package's module.
 
     If not provided or able to be determined, the version must be passed explicitly by the command line argument ``--version``.
 
 ``directory``
     The directory storing your news fragments.
 
-    For Python projects, the default is a ``newsfragments`` directory within the package.
-    For non-Python projects, the default is a ``newsfragments`` directory relative to the configuration file.
+    For Python projects that provide a ``package`` key, the default is a ``newsfragments`` directory within the package.
+    Otherwise the default is a ``newsfragments`` directory relative to the configuration file.
 
 ``filename``
     The filename of your news file.
@@ -121,7 +123,7 @@ Extra top level keys for Python projects
 ``package``
     The Python package name of your project.
 
-    Allows ``version`` to be automatically determined from the Python package version.
+    Allows ``name`` and ``version`` to be automatically determined from the Python package.
     Changes the default ``directory`` to be a ``newsfragments`` directory within this package.
 
 ``package_dir``

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -43,6 +43,9 @@ Top level keys
   For non-Python projects, the default is a ``newsfragments`` directory relative to the configuration file.
 - **``filename``** -- The filename of your news file.
   ``"NEWS.rst"`` by default.
+- **``template``** -- Path to the template for generating the news file.
+  If the path looks like ``<some.package>:<filename.ext>``, it is interpreted as a template bundled with an installed Python package.
+  ``"towncrier:default.rst"`` by default unless ``filename`` ends with ``.md``, in which case the default is ``"towncrier:default.md"``.
 - **``start_string``** -- The magic string that ``towncrier`` looks for when considering where the release notes should start.
   ``".. towncrier release notes start"`` by default.
 - **``title_format``** -- A format string for the title of your project.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -47,7 +47,7 @@ Top level keys
   If the path looks like ``<some.package>:<filename.ext>``, it is interpreted as a template bundled with an installed Python package.
   ``"towncrier:default.rst"`` by default unless ``filename`` ends with ``.md``, in which case the default is ``"towncrier:default.md"``.
 - **``start_string``** -- The magic string that ``towncrier`` looks for when considering where the release notes should start.
-  ``".. towncrier release notes start"`` by default.
+  ``".. towncrier release notes start\n"`` by default unless ``filename`` ends with ``.md``, in which case the default is ``"<!-- towncrier release notes start -->\n"``.
 - **``title_format``** -- A format string for the title of your project.
   The explicit value of ``False`` will disable the title entirely.
   Any other empty value means the template should render the title (the bundled templates use ``<name> <version> (<date>)``).

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -39,28 +39,10 @@ Top level keys
 - **``version``** -- The version of your project.
   Python projects that provide the ``package`` key can have the version to be automatically determined from a ``__version__`` variable in the package's module.
   The version can also be passed explicitly by command line argument ``--version``.
-- **``directory``** -- The directory storing you news fragments.
-  Mandatory except for Python projects (where the default is a ``newsfragments`` directory within the package).
-  The version can also be passed explicitly by command line argument ``--version``.
-- **``directory``** -- The directory storing you news fragments.
+- **``directory``** -- The directory storing your news fragments.
   Mandatory except for Python projects (where the default is a ``newsfragments`` directory within the package).
 - **``filename``** -- The filename of your news file.
   ``"NEWS.rst"`` by default.
-- **``title_format``** -- A format string for the title of your project.
-  The explicit value of ``False`` will disable the title entirely.
-  Any other empty value means the template should render the title (the bundled templates use ``<name> <version> (<date>)``).
-  Strings should use the following keys to render the title dynamically: ``{name}``, ``{version}``, and ``{project_date}``.
-  The explicit value of ``False`` will disable the title entirely.
-  Any other empty value means the template should render the title (the bundled templates use ``<name> <version> (<date>)``).
-- **``wrap``** -- Boolean value indicating whether to wrap news fragments to a line length of 79.
-- **``underlines``** -- The characters used for underlining headers.
-  Not used in the bundled Markdown template.
-- **``issue_format``** -- A format string for rendering the issue/ticket number in newsfiles.
-- **``single_file``** -- Boolean value indicating whether to write all news fragments to a single file.
-  If false, the ``filename`` should use the following keys to render the filenames dynamically:
-  ``{name}``, ``{version}``, and ``{project_date}``.
-- **``underlines``** -- The characters used for underlining headers.
-  Not used in the bundled Markdown template.
 - **``start_string``** -- The magic string that ``towncrier`` looks for when considering where the release notes should start.
   ``".. towncrier release notes start"`` by default.
 - **``title_format``** -- A format string for the title of your project.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -33,52 +33,101 @@ A minimal configuration for a non-Python project looks like this:
 Top level keys
 ~~~~~~~~~~~~~~
 
-- **``name``** -- The name of your project. If empty and the ``package`` key is provided, the name will be automatically determined.
-  ``""`` by default.
-- **``version``** -- The version of your project.
-  Python projects that provide the ``package`` key can have the version to be automatically determined from a ``__version__`` variable in the package's module.
-  The version can also be passed explicitly by command line argument ``--version``.
-- **``directory``** -- The directory storing your news fragments.
-  For Python projects, the default is a ``newsfragments`` directory within the package.
-  For non-Python projects, the default is a ``newsfragments`` directory relative to the configuration file.
-- **``filename``** -- The filename of your news file.
-  ``"NEWS.rst"`` by default.
-- **``template``** -- Path to the template for generating the news file.
-  If the path looks like ``<some.package>:<filename.ext>``, it is interpreted as a template bundled with an installed Python package.
-  ``"towncrier:default.rst"`` by default unless ``filename`` ends with ``.md``, in which case the default is ``"towncrier:default.md"``.
-- **``start_string``** -- The magic string that ``towncrier`` looks for when considering where the release notes should start.
-  ``".. towncrier release notes start\n"`` by default unless ``filename`` ends with ``.md``, in which case the default is ``"<!-- towncrier release notes start -->\n"``.
-- **``title_format``** -- A format string for the title of your project.
-  The explicit value of ``False`` will disable the title entirely.
-  Any other empty value means the template should render the title (the bundled templates use ``<name> <version> (<date>)``).
-  Strings should use the following keys to render the title dynamically: ``{name}``, ``{version}``, and ``{project_date}``.
-  ``""`` by default.
-- **``issue_format``** -- A format string for rendering the issue/ticket number in newsfiles.
-  If none, the issues are rendered as ``#<issue>`` if for issues that are integers, or just ``<issue>`` otherwise.
-  Use the ``{issue}`` key in your string render the issue number, for example Markdown projects may want to use ``"[{issue}]: https://<your bug tracker>/{issue}"``.
-  ``None`` by default.
-- **``underlines``** -- The characters used for underlining headers.
-  Not used in the bundled Markdown template.
-  ``["=", "-", "~"]`` by default.
-- **``wrap``** -- Boolean value indicating whether to wrap news fragments to a line length of 79.
-  ``false`` by default.
-- **``all_bullets``** -- Boolean value indicating whether the template uses bullets for each news fragment.
-  ``true`` by default.
-- **``single_file``** -- Boolean value indicating whether to write all news fragments to a single file.
-  If false, the ``filename`` should use the following keys to render the filenames dynamically:
-  ``{name}``, ``{version}``, and ``{project_date}``.
-  ``true`` by default.
-- **``orphan_prefix``** -- The prefix used for orphaned news fragments.
-  ``"+"`` by default.
-- **``path``** -- The path to the directory containing the news fragments for this section, relative to the configured ``directory``.
-  Use ``""`` for the root directory.
+``name``
+    The name of your project. If empty and the ``package`` key is provided, the name will be automatically determined.
+
+    ``""`` by default.
+
+``version``
+    The version of your project.
+
+    Python projects that provide the ``package`` key can have the version to be automatically determined from a ``__version__`` variable in the package's module (or the version if the package is installed).
+
+    If not provided or able to be determined, the version must be passed explicitly by the command line argument ``--version``.
+
+``directory``
+    The directory storing your news fragments.
+
+    For Python projects, the default is a ``newsfragments`` directory within the package.
+    For non-Python projects, the default is a ``newsfragments`` directory relative to the configuration file.
+
+``filename``
+    The filename of your news file.
+
+    ``"NEWS.rst"`` by default.
+
+``template``
+    Path to the template for generating the news file.
+
+    If the path looks like ``<some.package>:<filename.ext>``, it is interpreted as a template bundled with an installed Python package.
+
+    ``"towncrier:default.rst"`` by default unless ``filename`` ends with ``.md``, in which case the default is ``"towncrier:default.md"``.
+
+``start_string``
+    The magic string that ``towncrier`` looks for when considering where the release notes should start.
+
+    ``".. towncrier release notes start\n"`` by default unless ``filename`` ends with ``.md``, in which case the default is ``"<!-- towncrier release notes start -->\n"``.
+
+``title_format``
+    A format string for the title of your project.
+
+    The explicit value of ``False`` will disable the title entirely.
+    Any other empty value means the template should render the title (the bundled templates use ``<name> <version> (<date>)``).
+    Strings should use the following keys to render the title dynamically: ``{name}``, ``{version}``, and ``{project_date}``.
+
+    ``""`` by default.
+
+``issue_format``
+    A format string for rendering the issue/ticket number in newsfiles.
+
+    If none, the issues are rendered as ``#<issue>`` if for issues that are integers, or just ``<issue>`` otherwise.
+    Use the ``{issue}`` key in your string render the issue number, for example Markdown projects may want to use ``"[{issue}]: https://<your bug tracker>/{issue}"``.
+
+    ``None`` by default.
+
+``underlines``
+    The characters used for underlining headers.
+
+    Not used in the bundled Markdown template.
+
+    ``["=", "-", "~"]`` by default.
+
+``wrap``
+    Boolean value indicating whether to wrap news fragments to a line length of 79.
+
+    ``false`` by default.
+
+``all_bullets``
+    Boolean value indicating whether the template uses bullets for each news fragment.
+
+    ``true`` by default.
+
+``single_file``
+    Boolean value indicating whether to write all news fragments to a single file.
+
+    If ``false``, the ``filename`` should use the following keys to render the filenames dynamically:
+    ``{name}``, ``{version}``, and ``{project_date}``.
+
+    ``true`` by default.
+
+``orphan_prefix``
+    The prefix used for orphaned news fragments.
+
+    ``"+"`` by default.
 
 Extra top level keys for Python projects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **``package``** -- The package name of your project.
-- **``package_dir``** -- The folder your package lives.
-  ``"."`` by default, some projects might need to use ``"src"``.
+``package``
+    The Python package name of your project.
+
+    Allows ``version`` to be automatically determined from the Python package version.
+    Changes the default ``directory`` to be a ``newsfragments`` directory within this package.
+
+``package_dir``
+    The folder your package lives.
+
+    ``"."`` by default, some projects might need to use ``"src"``.
 
 
 Sections
@@ -86,13 +135,17 @@ Sections
 
 ``towncrier`` supports splitting fragments into multiple sections, each with its own news of fragment types.
 
-Add an array of tables your ``.toml`` configuration file named **``[[tool.towncrier.section]]``**.
+Add an array of tables your ``.toml`` configuration file named ``[[tool.towncrier.section]]``.
 
 Each table within this array has the following mandatory keys:
 
-- **``name``** -- The name of the section.
-- **``path``** -- The path to the directory containing the news fragments for this section, relative to the configured ``directory``.
-  Use ``""`` for the root directory.
+
+``name``
+    The name of the section.
+
+``path``
+    The path to the directory containing the news fragments for this section, relative to the configured ``directory``.
+    Use ``""`` for the root directory.
 
 For example:
 
@@ -118,14 +171,20 @@ You can use either of the two following method to define custom types instead (y
 Use TOML tables (alphabetical order)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Adding tables to your ``.toml`` configuration file named **``[tool.towncrier.fragment.<a custom fragment type>]``**.
+Adding tables to your ``.toml`` configuration file named ``[tool.towncrier.fragment.<a custom fragment type>]``.
 
 These may include the following optional keys:
 
-- **``name``** -- The description of the fragment type, as it must be included in the news file.
-  Defaults to its fragment type, but capitalized.
-- **``showcontent``** -- A boolean value indicating whether the fragment contents should be included in the news file.
-  ``true`` by default.
+
+``name``
+    The description of the fragment type, as it must be included in the news file.
+
+    Defaults to its fragment type, but capitalized.
+
+``showcontent``
+    A boolean value indicating whether the fragment contents should be included in the news file.
+
+    ``true`` by default.
 
 For example, if you want your custom fragment types to be ``["feat", "fix", "chore",]`` and you want all of them to use the default configuration except ``"chore"`` you can do it as follows:
 
@@ -149,17 +208,24 @@ For example, if you want your custom fragment types to be ``["feat", "fix", "cho
 Use a TOML Array (defined order)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Add an array of tables to your ``.toml`` configuration file named **``[[tool.towncrier.type]]``**.
+Add an array of tables to your ``.toml`` configuration file named ``[[tool.towncrier.type]]``.
 
 If you use this way to configure custom fragment types, ensure there is no ``tool.towncrier.fragment`` table.
 
 Each table within this array has the following mandatory keys:
 
-- **``directory``** -- The type / category of the fragment.
-- **``name``** -- The description of the fragment type, as it must be included
-  in the news file.
-- **``showcontent``** -- A boolean value indicating whether the fragment contents should be included in the news file.
-  ``true`` by default.
+
+``directory``
+    The type / category of the fragment.
+
+``name``
+    The description of the fragment type, as it must be included
+    in the news file.
+
+``showcontent``
+    A boolean value indicating whether the fragment contents should be included in the news file.
+
+    ``true`` by default.
 
 For example:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2,9 +2,9 @@ Configuration Reference
 =======================
 
 ``towncrier`` has many knobs and switches you can use, to customize it to your project's needs.
-The setup in the `Tutorial <tutorial.html>`_ doesn't touch on many, but this document will detail each of these options for you!
+The setup in the :doc:`tutorial` doesn't touch on many, but this document will detail each of these options for you!
 
-For how to perform common customization tasks, see `Customization <customization/index.html>`_.
+For how to perform common customization tasks, see :doc:`customization`.
 
 ``[tool.towncrier]``
 --------------------
@@ -37,28 +37,54 @@ Top level keys
 
 - **``name``** -- The name of your project. If empty and the ``package`` key is provided, the name will be automatically determined.
   ``""`` by default.
-- **``version``** -- The version of your project. Mandatory except for Python projects that provide the ``package`` key and want the version to be automatically determined from a ``__version__`` variable in the package's module.
-- **``directory``** -- The directory storing you news fragments. Mandatory except for Python projects (where the default is a ``newsfragments`` directory within the package).
+- **``version``** -- The version of your project.
+- **``directory``** -- The directory storing you news fragments.
+  Mandatory except for Python projects (where the default is a ``newsfragments`` directory within the package).
+  The version can also be passed explicitly by command line argument ``--version``.
+- **``directory``** -- The directory storing you news fragments.
+  Mandatory except for Python projects (where the default is a ``newsfragments`` directory within the package).
 - **``filename``** -- The filename of your news file.
   ``"NEWS.rst"`` by default.
-- **``template``** -- Path to the template for generating the news file. If the path starts with ``towncrier:``, it is interpreted as a template bundled with ``towncrier``.
-  ``"towncrier:default.rst"`` by default (unless ``filename`` ends with ``.md``, in which case the default is ``"towncrier:default.md"``).
+- **``title_format``** -- A format string for the title of your project.
+  The explicit value of ``False`` will disable the title entirely.
+  Any other empty value means the template should render the title (the bundled templates use ``<name> <version> (<date>)``).
+  Strings should use the following keys to render the title dynamically: ``{name}``, ``{version}``, and ``{project_date}``.
+  The explicit value of ``False`` will disable the title entirely.
+  Any other empty value means the template should render the title (the bundled templates use ``<name> <version> (<date>)``).
+- **``wrap``** -- Boolean value indicating whether to wrap news fragments to a line length of 79.
+- **``underlines``** -- The characters used for underlining headers.
+  Not used in the bundled Markdown template.
+- **``issue_format``** -- A format string for rendering the issue/ticket number in newsfiles.
+- **``single_file``** -- Boolean value indicating whether to write all news fragments to a single file.
+  If false, the ``filename`` should use the following keys to render the filenames dynamically:
+  ``{name}``, ``{version}``, and ``{project_date}``.
+- **``underlines``** -- The characters used for underlining headers.
+  Not used in the bundled Markdown template.
 - **``start_string``** -- The magic string that ``towncrier`` looks for when considering where the release notes should start.
   ``".. towncrier release notes start"`` by default.
-- **``title_format``** -- A format string for the title of your project. The explicit value of ``False`` will disable the title entirely. Any other empty value means the template should render the title (the bundled templates use ``<name> <version> (<date>)``). Strings should use the following keys to render the title dynamically: ``{name}``, ``{version}``, and ``{project_date}``.
+- **``title_format``** -- A format string for the title of your project.
+  The explicit value of ``False`` will disable the title entirely.
+  Any other empty value means the template should render the title (the bundled templates use ``<name> <version> (<date>)``).
+  Strings should use the following keys to render the title dynamically: ``{name}``, ``{version}``, and ``{project_date}``.
   ``""`` by default.
-- **``issue_format``** -- A format string for rendering the issue/ticket number in newsfiles. If none, the issues are rendered as ``#<issue>`` if for issues that are integers, or just ``<issue>`` otherwise. Use the ``{issue}`` key in your string render the issue number, for example Markdown projects may want to use ``"[{issue}]: https://<your bug tracker>/{issue}"``.
+- **``issue_format``** -- A format string for rendering the issue/ticket number in newsfiles.
+  If none, the issues are rendered as ``#<issue>`` if for issues that are integers, or just ``<issue>`` otherwise.
+  Use the ``{issue}`` key in your string render the issue number, for example Markdown projects may want to use ``"[{issue}]: https://<your bug tracker>/{issue}"``.
   ``None`` by default.
 - **``underlines``** -- The characters used for underlining headers. Not used in the bundled Markdown template.
   ``["=", "-", "~"]`` by default.
-- **``wrap``** -- Boolean value indicating whether to wrap news fragments to a width of 79.
+- **``wrap``** -- Boolean value indicating whether to wrap news fragments to a line length of 79.
   ``false`` by default.
 - **``all_bullets``** -- Boolean value indicating whether the template uses bullets for each news fragment.
   ``true`` by default.
-- **``single_file``** -- Boolean value indicating whether to write all news fragments to a single file. If false, the ``filename`` should use the following keys to render the filenames dynamically: ``{name}``, ``{version}``, and ``{project_date}``.
+- **``single_file``** -- Boolean value indicating whether to write all news fragments to a single file.
+  If false, the ``filename`` should use the following keys to render the filenames dynamically:
+  ``{name}``, ``{version}``, and ``{project_date}``.
   ``true`` by default.
 - **``orphan_prefix``** -- The prefix used for orphaned news fragments.
   ``"+"`` by default.
+- **``path``** -- The path to the directory containing the news fragments for this section, relative to the configured ``directory``.
+  Use ``""`` for the root directory.
 
 Extra top level keys for Python projects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -78,7 +104,8 @@ Add an array of tables your ``.toml`` configuration file named **``[[tool.towncr
 Each table within this array has the following mandatory keys:
 
 - **``name``** -- The name of the section.
-- **``path``** -- The path to the directory containing the news fragments for this section, relative to the configured ``directory``. Use ``""`` for the root directory.
+- **``path``** -- The path to the directory containing the news fragments for this section, relative to the configured ``directory``.
+  Use ``""`` for the root directory.
 
 For example:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -72,7 +72,8 @@ Top level keys
   If none, the issues are rendered as ``#<issue>`` if for issues that are integers, or just ``<issue>`` otherwise.
   Use the ``{issue}`` key in your string render the issue number, for example Markdown projects may want to use ``"[{issue}]: https://<your bug tracker>/{issue}"``.
   ``None`` by default.
-- **``underlines``** -- The characters used for underlining headers. Not used in the bundled Markdown template.
+- **``underlines``** -- The characters used for underlining headers.
+  Not used in the bundled Markdown template.
   ``["=", "-", "~"]`` by default.
 - **``wrap``** -- Boolean value indicating whether to wrap news fragments to a line length of 79.
   ``false`` by default.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,7 +4,7 @@ Configuration Reference
 ``towncrier`` has many knobs and switches you can use, to customize it to your project's needs.
 The setup in the :doc:`tutorial` doesn't touch on many, but this document will detail each of these options for you!
 
-For how to perform common customization tasks, see :doc:`customization`.
+For how to perform common customization tasks, see :doc:`customization/index`.
 
 ``[tool.towncrier]``
 --------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -30,7 +30,7 @@ A minimal configuration for a non-Python project looks like this:
    [tool.towncrier]
    name = "My Project"
    version = "1.0.0"
-   directory = "newsfragments" 
+   directory = "newsfragments"
 
 Top level keys
 ~~~~~~~~~~~~~~

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -29,7 +29,6 @@ A minimal configuration for a non-Python project looks like this:
 
    [tool.towncrier]
    name = "My Project"
-   version = "1.0.0"
    directory = "newsfragments"
 
 Top level keys
@@ -38,6 +37,8 @@ Top level keys
 - **``name``** -- The name of your project. If empty and the ``package`` key is provided, the name will be automatically determined.
   ``""`` by default.
 - **``version``** -- The version of your project.
+  Python projects that provide the ``package`` key can have the version to be automatically determined from a ``__version__`` variable in the package's module.
+  The version can also be passed explicitly by command line argument ``--version``.
 - **``directory``** -- The directory storing you news fragments.
   Mandatory except for Python projects (where the default is a ``newsfragments`` directory within the package).
   The version can also be passed explicitly by command line argument ``--version``.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -159,6 +159,21 @@ For example:
    name = "Secondary"
    path = "secondary"
 
+Section Path Behaviour
+~~~~~~~~~~~~~~~~~~~~~~
+
+The path behaviour is slightly different depending on whether ``directory`` is explicitly set.
+
+If ``directory`` is not set, "newsfragments" is added to the end of each path. For example, with the above sections, the paths would be:
+
+:Main Platform:  ./newsfragments
+:Secondary:      ./secondary/newsfragments
+
+If ``directory`` *is* set, the section paths are appended to this path. For example, with ``directory = "changes"`` and the above sections, the paths would be:
+
+:Main Platform:  ./changes
+:Secondary:      ./changes/secondary
+
 
 Custom fragment types
 ---------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -96,7 +96,7 @@ For example:
 Custom fragment types
 ---------------------
 
-``towncrier`` hase the following default fragment types: ``feature``, ``bugfix``, ``doc``, ``removal``, and ``misc``.
+``towncrier`` has the following default fragment types: ``feature``, ``bugfix``, ``doc``, ``removal``, and ``misc``.
 
 You can use either of the two following method to define custom types instead (you will need to redefine any of the default types you want to use).
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -29,7 +29,6 @@ A minimal configuration for a non-Python project looks like this:
 
    [tool.towncrier]
    name = "My Project"
-   directory = "newsfragments"
 
 Top level keys
 ~~~~~~~~~~~~~~
@@ -40,7 +39,8 @@ Top level keys
   Python projects that provide the ``package`` key can have the version to be automatically determined from a ``__version__`` variable in the package's module.
   The version can also be passed explicitly by command line argument ``--version``.
 - **``directory``** -- The directory storing your news fragments.
-  Mandatory except for Python projects (where the default is a ``newsfragments`` directory within the package).
+  For Python projects, the default is a ``newsfragments`` directory within the package.
+  For non-Python projects, the default is a ``newsfragments`` directory relative to the configuration file.
 - **``filename``** -- The filename of your news file.
   ``"NEWS.rst"`` by default.
 - **``start_string``** -- The magic string that ``towncrier`` looks for when considering where the release notes should start.

--- a/docs/customization/newsfile.rst
+++ b/docs/customization/newsfile.rst
@@ -5,30 +5,36 @@ Adding Content Above ``towncrier``
 ----------------------------------
 
 If you wish to have content at the top of the news file (for example, to say where you can find the tickets), you can use a special rST comment to tell ``towncrier`` to only update after it.
-In your existing news file (e.g. ``NEWS.rst``), add the following line above where you want ``towncrier`` to put content::
+In your existing news file (e.g. ``NEWS.rst``), add the following line above where you want ``towncrier`` to put content:
 
-  .. towncrier release notes start
+.. code-block:: restructuredtext
 
-In an existing news file, it'll look something like this::
+    .. towncrier release notes start
 
-  This is the changelog of my project. You can find the
-  issue tracker at http://blah.
+In an existing news file, it'll look something like this:
 
-  .. towncrier release notes start
+.. code-block:: restructuredtext
 
-  myproject 1.0.2 (2018-01-01)
-  ============================
+    This is the changelog of my project. You can find the
+    issue tracker at http://blah.
 
-  Bugfixes
-  --------
+    .. towncrier release notes start
 
-  - Fixed, etc...
+    myproject 1.0.2 (2018-01-01)
+    ============================
+
+    Bugfixes
+    --------
+
+    - Fixed, etc...
 
 ``towncrier`` will not alter content above the comment.
 
 Markdown
 ~~~~~~~~
 
-If your news file is in Markdown (e.g. ``NEWS.md``), use the following comment instead::
+If your news file is in Markdown (e.g. ``NEWS.md``), use the following comment instead:
 
-  <!--- towncrier release notes start -->
+.. code-block:: html
+
+    <!-- towncrier release notes start -->

--- a/docs/customization/newsfile.rst
+++ b/docs/customization/newsfile.rst
@@ -25,3 +25,10 @@ In an existing news file, it'll look something like this::
   - Fixed, etc...
 
 ``towncrier`` will not alter content above the comment.
+
+Markdown
+~~~~~~~~
+
+If your news file is in Markdown (e.g. ``NEWS.md``), use the following comment instead::
+
+  <!--- towncrier release notes start -->

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,7 +1,7 @@
 Tutorial
 ========
 
-This tutorial assumes you have a Python project with a *reStructuredText* (rst) or *markdown* (md) news file (also known as changelog) file that you wish to use ``towncrier`` on, to generate its news file.
+This tutorial assumes you have a Python project with a *reStructuredText* (rst) or *Markdown* (md) news file (also known as changelog) that you wish to use ``towncrier`` on, to generate its news file.
 It will cover setting up your project with a basic configuration, which you can then feel free to `customize <customization/index.html>`_.
 
 Install from PyPI::
@@ -144,7 +144,7 @@ You should get an output similar to this::
 
    - #1, #2
 
-Note: if you configure a markdown file (for example, ``filename = "CHANGES.md"`` in your configuration file), the titles will be output in markdown format instead.
+Note: if you configure a Markdown file (for example, ``filename = "CHANGES.md"``) in your configuration file, the titles will be output in markdown format instead.
 
 
 Producing News Files In Production

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -144,7 +144,7 @@ You should get an output similar to this::
 
    - #1, #2
 
-Note: if you configure a Markdown file (for example, ``filename = "CHANGES.md"``) in your configuration file, the titles will be output in markdown format instead.
+Note: if you configure a Markdown file (for example, ``filename = "CHANGES.md"``) in your configuration file, the titles will be output in Markdown format instead.
 
 
 Producing News Files In Production

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,7 +1,7 @@
 Tutorial
 ========
 
-This tutorial assumes you have a Python project with a *reStructuredText* (rst) news file (also known as changelog) file that you wish to use ``towncrier`` on, to generate its news file.
+This tutorial assumes you have a Python project with a *reStructuredText* (rst) or *markdown* (md) news file (also known as changelog) file that you wish to use ``towncrier`` on, to generate its news file.
 It will cover setting up your project with a basic configuration, which you can then feel free to `customize <customization/index.html>`_.
 
 Install from PyPI::
@@ -143,6 +143,8 @@ You should get an output similar to this::
    ----
 
    - #1, #2
+
+Note: if you configure a markdown file (for example, ``filename = "CHANGES.md"`` in your configuration file), the titles will be output in markdown format instead.
 
 
 Producing News Files In Production

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -163,6 +163,8 @@ If you wish to have content at the top of the news file (for example, to say whe
 
 ``towncrier`` will then put the version notes after this comment, and leave your existing content that was above it where it is.
 
+Note: if you configure a Markdown file (for example, ``filename = "CHANGES.md"``) in your configuration file, the comment should be ``<!-- towncrier release notes start -->`` instead.
+
 
 Finale
 ------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,12 @@ profile = "attrs"
 line_length = 88
 
 
+[tool.ruff.isort]
+# Match isort's "attrs" profile
+lines-after-imports = 2
+lines-between-types = 1
+
+
 [tool.mypy]
 strict = true
 # 2022-09-04: Trial's API isn't annotated yet, which limits the usefulness of type-checking

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires-python = ">=3.7"
 dependencies = [
     "click",
     "click-default-group",
-    "importlib-resources>1.3; python_version<'3.9'",
+    "importlib-resources>=5; python_version<'3.10'",
     "incremental",
     "jinja2",
     "tomli; python_version<'3.11'",

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -66,15 +66,14 @@ def parse_newfragment_basename(
 
 # Returns a structure like:
 #
-# {[
-#   ("",
-#    {
-#      ("142", "misc"): u"",
-#      ("1", "feature"): u"some cool description",
-#    }),
-#   ("Names", {}),
-#   ("Web", {("3", "bugfix"): u"Fixed a thing"}),
-# ]}
+# {
+#     "": {
+#         ("142", "misc"): "",
+#         ("1", "feature"): "some cool description",
+#     },
+#     "Names": {},
+#     "Web": {("3", "bugfix"): "Fixed a thing"},
+# }
 #
 # We should really use attrs.
 #

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -8,7 +8,7 @@ import os
 import textwrap
 import traceback
 
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from typing import Any, DefaultDict, Iterable, Iterator, Mapping, Sequence
 
 from jinja2 import Template
@@ -66,7 +66,7 @@ def parse_newfragment_basename(
 
 # Returns a structure like:
 #
-# OrderedDict([
+# {[
 #   ("",
 #    {
 #      ("142", "misc"): u"",
@@ -74,7 +74,7 @@ def parse_newfragment_basename(
 #    }),
 #   ("Names", {}),
 #   ("Web", {("3", "bugfix"): u"Fixed a thing"}),
-# ])
+# ]}
 #
 # We should really use attrs.
 #
@@ -89,7 +89,7 @@ def find_fragments(
     """
     Sections are a dictonary of section names to paths.
     """
-    content = OrderedDict()
+    content = {}
     fragment_filenames = []
     # Multiple orphan news fragments are allowed per section, so initialize a counter
     # that can be incremented automatically.
@@ -164,7 +164,7 @@ def split_fragments(
     definitions: Mapping[str, Mapping[str, Any]],
     all_bullets: bool = True,
 ) -> Mapping[str, Mapping[str, Mapping[str, Sequence[str]]]]:
-    output = OrderedDict()
+    output = {}
 
     for section_name, section_fragments in fragments.items():
         section: dict[str, dict[str, list[str]]] = {}
@@ -182,7 +182,7 @@ def split_fragments(
             if definitions[category]["showcontent"] is False:
                 content = ""
 
-            texts = section.setdefault(category, OrderedDict())
+            texts = section.setdefault(category, {})
 
             tickets = texts.setdefault(content, [])
             if ticket:
@@ -288,7 +288,7 @@ def render_fragments(
 
             # Then we put these nicely sorted entries back in an ordered dict
             # for the template, after formatting each issue number
-            categories = OrderedDict()
+            categories = {}
             for text, issues in entries:
                 rendered = [render_issue(issue_format, i) for i in issues]
                 categories[text] = rendered

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -263,7 +263,7 @@ def render_fragments(
         issues_by_category[section_name] = {}
 
         for category_name, category_value in section_value.items():
-            category_issues = set()
+            category_issues: set[str] = set()
             # Suppose we start with an ordering like this:
             #
             # - Fix the thing (#7, #123, #2)

--- a/src/towncrier/_settings/fragment_types.py
+++ b/src/towncrier/_settings/fragment_types.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-import collections as clt
 
 from typing import Any, Iterable, Mapping
 
@@ -36,7 +35,7 @@ class BaseFragmentTypesLoader:
 class DefaultFragmentTypesLoader(BaseFragmentTypesLoader):
     """Default towncrier's fragment types."""
 
-    _default_types = clt.OrderedDict(
+    _default_types = {
         [
             # Keep in-sync with docs/tutorial.rst.
             ("feature", {"name": "Features", "showcontent": True}),
@@ -45,7 +44,7 @@ class DefaultFragmentTypesLoader(BaseFragmentTypesLoader):
             ("removal", {"name": "Deprecations and Removals", "showcontent": True}),
             ("misc", {"name": "Misc", "showcontent": False}),
         ]
-    )
+    }
 
     def load(self) -> Mapping[str, Mapping[str, Any]]:
         """Load default types."""
@@ -72,7 +71,7 @@ class ArrayFragmentTypesLoader(BaseFragmentTypesLoader):
     def load(self) -> Mapping[str, Mapping[str, Any]]:
         """Load types from toml array of mappings."""
 
-        types = clt.OrderedDict()
+        types = {}
         types_config = self.config["type"]
         for type_config in types_config:
             directory = type_config["directory"]
@@ -123,7 +122,7 @@ class TableFragmentTypesLoader(BaseFragmentTypesLoader):
             (fragment_type, self._load_options(fragment_type))
             for fragment_type in fragment_types
         ]
-        types = clt.OrderedDict(custom_types_sequence)
+        types = dict(custom_types_sequence)
         return types
 
     def _load_options(self, fragment_type: str) -> Mapping[str, Any]:

--- a/src/towncrier/_settings/fragment_types.py
+++ b/src/towncrier/_settings/fragment_types.py
@@ -36,14 +36,12 @@ class DefaultFragmentTypesLoader(BaseFragmentTypesLoader):
     """Default towncrier's fragment types."""
 
     _default_types = {
-        [
-            # Keep in-sync with docs/tutorial.rst.
-            ("feature", {"name": "Features", "showcontent": True}),
-            ("bugfix", {"name": "Bugfixes", "showcontent": True}),
-            ("doc", {"name": "Improved Documentation", "showcontent": True}),
-            ("removal", {"name": "Deprecations and Removals", "showcontent": True}),
-            ("misc", {"name": "Misc", "showcontent": False}),
-        ]
+        # Keep in-sync with docs/tutorial.rst.
+        "feature": {"name": "Features", "showcontent": True},
+        "bugfix": {"name": "Bugfixes", "showcontent": True},
+        "doc": {"name": "Improved Documentation", "showcontent": True},
+        "removal": {"name": "Deprecations and Removals", "showcontent": True},
+        "misc": {"name": "Misc", "showcontent": False},
     }
 
     def load(self) -> Mapping[str, Mapping[str, Any]]:

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -7,7 +7,7 @@ import dataclasses
 import os
 import sys
 
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
 import pkg_resources
 
@@ -43,7 +43,7 @@ class Config:
     start_string: str = ".. towncrier release notes start\n"
     title_format: str | Literal[False] = ""
     issue_format: str | None = None
-    underlines: list[str] = dataclasses.field(default_factory=lambda: ["=", "-", "~"])
+    underlines: Sequence[str] = ("=", "-", "~")
     wrap: bool = False
     all_bullets: bool = True
     orphan_prefix: str = "+"

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     else:
         from typing import Literal
 
-if sys.version_info < (3, 9):
+if sys.version_info < (3, 10):
     import importlib_resources as resources
 else:
     from importlib import resources

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -122,7 +122,8 @@ def parse_toml(base_path: str, config: Mapping[str, Any]) -> Config:
             # Skip these options, they are processed later.
             continue
         if field.name in config:
-            if field.type == "bool":
+            #  Interestingly, the __future__ annotation turns the type into a string.
+            if field.type in ("bool", bool):
                 if not isinstance(config[field.name], bool):
                     raise ConfigError(
                         f"`{field.name}` option must be boolean: false or true.",
@@ -146,21 +147,21 @@ def parse_toml(base_path: str, config: Mapping[str, Any]) -> Config:
     # Process 'template'.
     template = config.get("template", "towncrier:default")
     if template.startswith("towncrier:"):
-        resource_filename = template.split(":", 1)[1]
-        if not os.path.splitext(resource_filename)[1]:
+        resource_name = "templates/" + template.split(":", 1)[1]
+        if not os.path.splitext(resource_name)[1]:
             # Choose the default template based on the filename extension.
             if os.path.splitext(config.get("filename", ""))[
                 1
             ] == ".md" and pkg_resources.resource_exists(
-                "towncrier", f"{resource_filename}.md"
+                "towncrier", f"{resource_name}.md"
             ):
-                resource_filename += ".md"
+                resource_name += ".md"
             else:
-                resource_filename += ".rst"
-        resource_name = "templates/" + resource_filename
+                resource_name += ".rst"
         if not pkg_resources.resource_exists("towncrier", resource_name):
             raise ConfigError(
-                f"Towncrier does not have a template named '{resource_filename}'.",
+                "Towncrier does not have a template named "
+                f"'{os.path.basename(resource_name)}'.",
                 failing_option="template",
             )
         template = pkg_resources.resource_filename("towncrier", resource_name)

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -3,11 +3,10 @@
 
 from __future__ import annotations
 
+import dataclasses
 import os
 import sys
 
-from collections import OrderedDict
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Mapping
 
 import pkg_resources
@@ -29,37 +28,31 @@ else:
     import tomllib
 
 
-@dataclass
+@dataclasses.dataclass
 class Config:
-    package: str
-    package_dir: str
-    single_file: bool
-    filename: str
-    directory: str | None
-    version: str | None
-    name: str | None
     sections: Mapping[str, str]
     types: Mapping[str, Mapping[str, Any]]
     template: str
-    start_string: str
-    title_format: str | Literal[False]
-    issue_format: str | None
-    underlines: list[str]
-    wrap: bool
-    all_bullets: bool
-    orphan_prefix: str
+    package: str = ""
+    package_dir: str = "."
+    single_file: bool = True
+    filename: str = "NEWS.rst"
+    directory: str | None = None
+    version: str | None = None
+    name: str = ""
+    start_string: str = ".. towncrier release notes start\n"
+    title_format: str | Literal[False] = ""
+    issue_format: str | None = None
+    underlines: list[str] = dataclasses.field(default_factory=lambda: ["=", "-", "~"])
+    wrap: bool = False
+    all_bullets: bool = True
+    orphan_prefix: str = "+"
 
 
 class ConfigError(Exception):
     def __init__(self, *args: str, **kwargs: str):
         self.failing_option = kwargs.get("failing_option")
         super().__init__(*args)
-
-
-_start_string = ".. towncrier release notes start\n"
-_title_format = None
-_template_fname = "towncrier:default"
-_underlines = ["=", "-", "~"]
 
 
 def load_config_from_options(
@@ -107,52 +100,69 @@ def load_config_from_file(directory: str, config_file: str) -> Config:
 
 
 def parse_toml(base_path: str, config: Mapping[str, Any]) -> Config:
-    if "tool" not in config:
+    if "towncrier" not in (config.get("tool") or {}):
         raise ConfigError("No [tool.towncrier] section.", failing_option="all")
 
     config = config["tool"]["towncrier"]
+    parsed_data = {}
 
-    sections = OrderedDict()
+    # Check for misspelt options.
+    for typo, correct in [
+        ("singlefile", "single_file"),
+    ]:
+        if config.get(typo):
+            raise ConfigError(
+                f"`{typo}` is not a valid option. Did you mean `{correct}`?",
+                failing_option=typo,
+            )
+
+    # Process options.
+    for field in dataclasses.fields(Config):
+        if field.name in ("sections", "types", "template"):
+            # Skip these options, they are processed later.
+            continue
+        if field.name in config:
+            if field.type == "bool":
+                if not isinstance(config[field.name], bool):
+                    raise ConfigError(
+                        f"`{field.name}` option must be boolean: false or true.",
+                        failing_option=field.name,
+                    )
+            parsed_data[field.name] = config[field.name]
+
+    # Process 'section'.
+    sections = {}
     if "section" in config:
         for x in config["section"]:
             sections[x.get("name", "")] = x["path"]
     else:
         sections[""] = ""
+    parsed_data["sections"] = sections
+
+    # Process 'types'.
     fragment_types_loader = ft.BaseFragmentTypesLoader.factory(config)
-    types = fragment_types_loader.load()
+    parsed_data["types"] = fragment_types_loader.load()
 
-    wrap = config.get("wrap", False)
-
-    single_file_wrong = config.get("singlefile")
-    if single_file_wrong:
-        raise ConfigError(
-            "`singlefile` is not a valid option. Did you mean `single_file`?",
-            failing_option="singlefile",
-        )
-
-    single_file = config.get("single_file", True)
-    if not isinstance(single_file, bool):
-        raise ConfigError(
-            "`single_file` option must be a boolean: false or true.",
-            failing_option="single_file",
-        )
-
-    all_bullets = config.get("all_bullets", True)
-    if not isinstance(all_bullets, bool):
-        raise ConfigError(
-            "`all_bullets` option must be boolean: false or true.",
-            failing_option="all_bullets",
-        )
-
-    template = config.get("template", _template_fname)
+    # Process 'template'.
+    template = config.get("template", "towncrier:default")
     if template.startswith("towncrier:"):
-        resource_name = "templates/" + template.split("towncrier:", 1)[1] + ".rst"
+        resource_filename = template.split(":", 1)[1]
+        if not os.path.splitext(resource_filename)[1]:
+            # Choose the default template based on the filename extension.
+            if os.path.splitext(config.get("filename", ""))[
+                1
+            ] == ".md" and pkg_resources.resource_exists(
+                "towncrier", f"{resource_filename}.md"
+            ):
+                resource_filename += ".md"
+            else:
+                resource_filename += ".rst"
+        resource_name = "templates/" + resource_filename
         if not pkg_resources.resource_exists("towncrier", resource_name):
             raise ConfigError(
-                "Towncrier does not have a template named '%s'."
-                % (template.split("towncrier:", 1)[1],)
+                f"Towncrier does not have a template named '{resource_filename}'.",
+                failing_option="template",
             )
-
         template = pkg_resources.resource_filename("towncrier", resource_name)
     else:
         template = os.path.join(base_path, template)
@@ -162,23 +172,7 @@ def parse_toml(base_path: str, config: Mapping[str, Any]) -> Config:
             f"The template file '{template}' does not exist.",
             failing_option="template",
         )
+    parsed_data["template"] = template
 
-    return Config(
-        package=config.get("package", ""),
-        package_dir=config.get("package_dir", "."),
-        single_file=single_file,
-        filename=config.get("filename", "NEWS.rst"),
-        directory=config.get("directory"),
-        version=config.get("version"),
-        name=config.get("name"),
-        sections=sections,
-        types=types,
-        template=template,
-        start_string=config.get("start_string", _start_string),
-        title_format=config.get("title_format", _title_format),
-        issue_format=config.get("issue_format"),
-        underlines=config.get("underlines", _underlines),
-        wrap=wrap,
-        all_bullets=all_bullets,
-        orphan_prefix=config.get("orphan_prefix", "+"),
-    )
+    # Return the parsed config.
+    return Config(**parsed_data)

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -25,7 +25,7 @@ from ._settings import ConfigError, config_option_help, load_config_from_options
 from ._writer import append_to_newsfile
 
 
-if sys.version_info < (3, 9):
+if sys.version_info < (3, 10):
     import importlib_resources as resources
 else:
     from importlib import resources

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -156,8 +156,8 @@ def __main(
         package, resource = config.template.split(":", 1)
         template = resources.read_text(package, resource)
     else:
-        with open(config.template, encoding="utf-8") as tmpl:
-            template = tmpl.read()
+        with open(config.template, "rb") as tmpl:
+            template = tmpl.read().decode("utf8")
 
     click.echo("Finding news fragments...", err=to_err)
 

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -152,12 +152,11 @@ def __main(
     to_err = draft
 
     click.echo("Loading template...", err=to_err)
-    if ":" in config.template:
-        package, resource = config.template.split(":", 1)
-        template = resources.read_text(package, resource)
+    if isinstance(config.template, tuple):
+        template = resources.read_text(*config.template)
     else:
-        with open(config.template, "rb") as tmpl:
-            template = tmpl.read().decode("utf8")
+        with open(config.template, encoding="utf-8") as tmpl:
+            template = tmpl.read()
 
     click.echo("Finding news fragments...", err=to_err)
 

--- a/src/towncrier/newsfragments/483.feature
+++ b/src/towncrier/newsfragments/483.feature
@@ -1,3 +1,3 @@
-Provide a default Markdown template if the configured filename ends with `.md`.
+Provide a default Markdown template if the configured filename ends with ``.md``.
 
 The Markdown template uses the same rendered format as the default *reStructuredText* template, but with a Markdown syntax.

--- a/src/towncrier/newsfragments/483.feature
+++ b/src/towncrier/newsfragments/483.feature
@@ -1,0 +1,3 @@
+Provide a default Markdown template if the configured filename ends with `.md`.
+
+The Markdown template uses the same rendered format as the default *reStructuredText* template, but with a Markdown syntax.

--- a/src/towncrier/newsfragments/483.feature.rst
+++ b/src/towncrier/newsfragments/483.feature.rst
@@ -1,3 +1,0 @@
-Provide a default Markdown template if the configured filename ends with `.md`.
-
-The Markdown template uses the same rendered format as the default _reStructuredText_ template, but with a Markdown syntax.

--- a/src/towncrier/newsfragments/483.feature.rst
+++ b/src/towncrier/newsfragments/483.feature.rst
@@ -1,3 +1,3 @@
-Provide a default markdown template if the configured filename ends with `.md`.
+Provide a default Markdown template if the configured filename ends with `.md`.
 
-The markdown template uses the same rendered format as the default ReStructuredText template, but with a markdown syntax.
+The Markdown template uses the same rendered format as the default _reStructuredText_ template, but with a Markdown syntax.

--- a/src/towncrier/newsfragments/483.feature.rst
+++ b/src/towncrier/newsfragments/483.feature.rst
@@ -1,0 +1,3 @@
+Provide a default markdown template if the configured filename ends with `.md`.
+
+The markdown template uses the same rendered format as the default ReStructuredText template, but with a markdown syntax.

--- a/src/towncrier/templates/default.md
+++ b/src/towncrier/templates/default.md
@@ -1,0 +1,61 @@
+{% if render_title %}
+{% if versiondata.name %}
+# {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
+{% else %}
+{{ versiondata.version }} ({{ versiondata.date }})
+{% endif %}
+{% endif %}
+{% for section, _ in sections.items() %}
+{% if section %}
+
+## {{section}}
+{% endif %}
+
+{% if sections[section] %}
+{% for category, val in definitions.items() if category in sections[section] %}
+### {{ definitions[category]['name'] }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, values in sections[section][category].items() %}
+- {{ text }}
+{%- if values %}
+{% if "\n  - " in text or '\n  * ' in text %}
+
+
+  (
+{%- else %}
+ (
+{%- endif -%}
+{%- for issue in values %}
+{{ issue.split(": ", 1)[0] }}{% if not loop.last %}, {% endif %}
+{%- endfor %}
+)
+{% else %}
+
+{% endif %}
+{% endfor %}
+
+{% else %}
+- {% for issue in sections[section][category][''] %}
+{{ issue.split(": ", 1)[0] }}{% if not loop.last %}, {% endif %}
+{% endfor %}
+
+
+{% endif %}
+{% if issues_by_category[section][category] and "]: " in issues_by_category[section][category][0] %}
+{% for issue in issues_by_category[section][category] %}
+{{ issue }}
+{% endfor %}
+
+{% endif %}
+{% if sections[section][category]|length == 0 %}
+No significant changes.
+
+{% else %}
+{% endif %}
+{% endfor %}
+{% else %}
+No significant changes.
+
+{% endif %}
+{% endfor %}

--- a/src/towncrier/test/helpers.py
+++ b/src/towncrier/test/helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import textwrap
 
 from functools import wraps
 from pathlib import Path
@@ -19,12 +20,14 @@ def read(filename: str | Path) -> str:
     return Path(filename).read_text()
 
 
-def write(path: str | Path, contents: str) -> None:
+def write(path: str | Path, contents: str, dedent: bool = False) -> None:
     """
     Create a file with given contents including any missing parent directories
     """
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
+    if dedent:
+        contents = textwrap.dedent(contents)
     p.write_text(contents)
 
 

--- a/src/towncrier/test/helpers.py
+++ b/src/towncrier/test/helpers.py
@@ -9,7 +9,7 @@ from typing import Any, Callable
 from click.testing import CliRunner
 
 
-if sys.version_info < (3, 10):
+if sys.version_info < (3, 9):
     import importlib_resources as resources
 else:
     from importlib import resources

--- a/src/towncrier/test/helpers.py
+++ b/src/towncrier/test/helpers.py
@@ -9,7 +9,7 @@ from typing import Any, Callable
 from click.testing import CliRunner
 
 
-if sys.version_info < (3, 9):
+if sys.version_info < (3, 10):
     import importlib_resources as resources
 else:
     from importlib import resources

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -15,7 +15,7 @@ from twisted.trial.unittest import TestCase
 
 from .._shell import cli
 from ..build import _main
-from .helpers import read, setup_simple_project, with_isolated_runner
+from .helpers import read, setup_simple_project, with_isolated_runner, write
 
 
 class TestCli(TestCase):
@@ -1170,22 +1170,20 @@ Deprecations and Removals
         """
         setup_simple_project()
 
-        with open("foo/newsfragments/123.feature", "w") as f:
-            f.write("Adds levitation")
-        with open("NEWS.rst", "w") as f:
-            f.write(
-                dedent(
-                    """
-                    a line
+        write("foo/newsfragments/123.feature", "Adds levitation")
+        write(
+            "NEWS.rst",
+            contents="""
+                a line
 
-                    another
+                another
 
-                    .. towncrier release notes start
+                .. towncrier release notes start
 
-                    a footer!
-                    """
-                )
-            )
+                a footer!
+            """,
+            dedent=True,
+        )
 
         result = runner.invoke(_main, ["--date", "01-01-2001"], catch_exceptions=False)
         self.assertEqual(0, result.exit_code, result.output)
@@ -1222,22 +1220,20 @@ Deprecations and Removals
         """
         setup_simple_project(extra_config='filename = "NEWS.md"')
 
-        with open("foo/newsfragments/123.feature", "w") as f:
-            f.write("Adds levitation")
-        with open("NEWS.md", "w") as f:
-            f.write(
-                dedent(
-                    """
-                    a line
+        write("foo/newsfragments/123.feature", "Adds levitation")
+        write(
+            "NEWS.md",
+            contents="""
+                a line
 
-                    another
+                another
 
-                    <!-- towncrier release notes start -->
+                <!-- towncrier release notes start -->
 
-                    a footer!
-                    """
-                )
-            )
+                a footer!
+            """,
+            dedent=True,
+        )
 
         result = runner.invoke(_main, ["--date", "01-01-2001"], catch_exceptions=False)
         self.assertEqual(0, result.exit_code, result.output)

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1163,6 +1163,107 @@ Deprecations and Removals
 
         self.assertEqual(expected_output, output)
 
+    @with_isolated_runner
+    def test_default_start_string(self, runner):
+        """
+        The default start string is ``.. towncrier release notes start``.
+        """
+        setup_simple_project()
+
+        with open("foo/newsfragments/123.feature", "w") as f:
+            f.write("Adds levitation")
+        with open("NEWS.rst", "w") as f:
+            f.write(
+                dedent(
+                    """
+                    a line
+
+                    another
+
+                    .. towncrier release notes start
+
+                    a footer!
+                    """
+                )
+            )
+
+        result = runner.invoke(_main, ["--date", "01-01-2001"], catch_exceptions=False)
+        self.assertEqual(0, result.exit_code, result.output)
+        output = read("NEWS.rst")
+
+        expected_output = dedent(
+            """
+            a line
+
+            another
+
+            .. towncrier release notes start
+
+            Foo 1.2.3 (01-01-2001)
+            ======================
+
+            Features
+            --------
+
+            - Adds levitation (#123)
+
+
+            a footer!
+            """
+        )
+
+        self.assertEqual(expected_output, output)
+
+    @with_isolated_runner
+    def test_default_start_string_markdown(self, runner):
+        """
+        The default start string is ``<!-- towncrier release notes start -->`` for
+        Markdown.
+        """
+        setup_simple_project(extra_config='filename = "NEWS.md"')
+
+        with open("foo/newsfragments/123.feature", "w") as f:
+            f.write("Adds levitation")
+        with open("NEWS.md", "w") as f:
+            f.write(
+                dedent(
+                    """
+                    a line
+
+                    another
+
+                    <!-- towncrier release notes start -->
+
+                    a footer!
+                    """
+                )
+            )
+
+        result = runner.invoke(_main, ["--date", "01-01-2001"], catch_exceptions=False)
+        self.assertEqual(0, result.exit_code, result.output)
+        output = read("NEWS.md")
+
+        expected_output = dedent(
+            """
+            a line
+
+            another
+
+            <!-- towncrier release notes start -->
+
+            # Foo 1.2.3 (01-01-2001)
+
+            ### Features
+
+            - Adds levitation (#123)
+
+
+            a footer!
+            """
+        )
+
+        self.assertEqual(expected_output, output)
+
     def test_with_topline_and_template_and_draft(self):
         """
         Spacing is proper when drafting with a topline and a template.

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1080,6 +1080,7 @@ Deprecations and Removals
                     "20-01-2001",
                     "--draft",
                 ],
+                catch_exceptions=False,
             )
 
         expected_output = dedent(

--- a/src/towncrier/test/test_format.py
+++ b/src/towncrier/test/test_format.py
@@ -331,6 +331,7 @@ No significant changes.
             wrap=True,
             versiondata={"name": "MyProject", "version": "1.0", "date": "never"},
         )
+
         self.assertEqual(output, expected_output)
 
     def test_issue_format(self):

--- a/src/towncrier/test/test_format.py
+++ b/src/towncrier/test/test_format.py
@@ -40,11 +40,9 @@ class FormatterTests(TestCase):
         }
 
         definitions = {
-            [
-                ("feature", {"name": "Features", "showcontent": True}),
-                ("bugfix", {"name": "Bugfixes", "showcontent": True}),
-                ("misc", {"name": "Misc", "showcontent": False}),
-            ]
+            "feature": {"name": "Features", "showcontent": True},
+            "bugfix": {"name": "Bugfixes", "showcontent": True},
+            "misc": {"name": "Misc", "showcontent": False},
         }
 
         output = split_fragments(fragments, definitions)
@@ -57,34 +55,27 @@ class FormatterTests(TestCase):
         them into a rST file -- works.
         """
         fragments = {
-            [
-                (
-                    "",
-                    {
-                        # asciibetical sorting will do 1, 142, 9
-                        # we want 1, 9, 142 instead
-                        ("142", "misc", 0): "",
-                        ("1", "misc", 0): "",
-                        ("9", "misc", 0): "",
-                        ("bar", "misc", 0): "",
-                        ("4", "feature", 0): "Stuff!",
-                        ("2", "feature", 0): "Foo added.",
-                        ("72", "feature", 0): "Foo added.",
-                        ("9", "feature", 0): "Foo added.",
-                        ("baz", "feature", 0): "Fun!",
-                    },
-                ),
-                ("Names", {}),
-                ("Web", {("3", "bugfix", 0): "Web fixed."}),
-            ]
+            "": {
+                # asciibetical sorting will do 1, 142, 9
+                # we want 1, 9, 142 instead
+                ("142", "misc", 0): "",
+                ("1", "misc", 0): "",
+                ("9", "misc", 0): "",
+                ("bar", "misc", 0): "",
+                ("4", "feature", 0): "Stuff!",
+                ("2", "feature", 0): "Foo added.",
+                ("72", "feature", 0): "Foo added.",
+                ("9", "feature", 0): "Foo added.",
+                ("baz", "feature", 0): "Fun!",
+            },
+            "Names": {},
+            "Web": {("3", "bugfix", 0): "Web fixed."},
         }
 
         definitions = {
-            [
-                ("feature", {"name": "Features", "showcontent": True}),
-                ("bugfix", {"name": "Bugfixes", "showcontent": True}),
-                ("misc", {"name": "Misc", "showcontent": False}),
-            ]
+            "feature": {"name": "Features", "showcontent": True},
+            "bugfix": {"name": "Bugfixes", "showcontent": True},
+            "misc": {"name": "Misc", "showcontent": False},
         }
 
         expected_output = """MyProject 1.0 (never)
@@ -184,44 +175,31 @@ Bugfixes
         Check formating of default markdown template.
         """
         fragments = {
-            [
-                (
-                    "",
-                    {
-                        # asciibetical sorting will do 1, 142, 9
-                        # we want 1, 9, 142 instead
-                        ("142", "misc", 0): "",
-                        ("1", "misc", 0): "",
-                        ("9", "misc", 0): "",
-                        ("bar", "misc", 0): "",
-                        ("4", "feature", 0): "Stuff!",
-                        ("2", "feature", 0): "Foo added.",
-                        ("72", "feature", 0): "Foo added.",
-                        ("9", "feature", 0): "Foo added.",
-                        ("3", "feature", 0): "Multi-line\nhere",
-                        ("baz", "feature", 0): "Fun!",
-                    },
-                ),
-                (
-                    "Names",
-                    {},
-                ),
-                (
-                    "Web",
-                    {
-                        ("3", "bugfix", 0): "Web fixed.",
-                        ("2", "bugfix", 0): "Multi-line bulleted\n- fix\n- here",
-                    },
-                ),
-            ]
+            "": {
+                # asciibetical sorting will do 1, 142, 9
+                # we want 1, 9, 142 instead
+                ("142", "misc", 0): "",
+                ("1", "misc", 0): "",
+                ("9", "misc", 0): "",
+                ("bar", "misc", 0): "",
+                ("4", "feature", 0): "Stuff!",
+                ("2", "feature", 0): "Foo added.",
+                ("72", "feature", 0): "Foo added.",
+                ("9", "feature", 0): "Foo added.",
+                ("3", "feature", 0): "Multi-line\nhere",
+                ("baz", "feature", 0): "Fun!",
+            },
+            "Names": {},
+            "Web": {
+                ("3", "bugfix", 0): "Web fixed.",
+                ("2", "bugfix", 0): "Multi-line bulleted\n- fix\n- here",
+            },
         }
 
         definitions = {
-            [
-                ("feature", {"name": "Features", "showcontent": True}),
-                ("bugfix", {"name": "Bugfixes", "showcontent": True}),
-                ("misc", {"name": "Misc", "showcontent": False}),
-            ]
+            "feature": {"name": "Features", "showcontent": True},
+            "bugfix": {"name": "Bugfixes", "showcontent": True},
+            "misc": {"name": "Misc", "showcontent": False},
         }
 
         expected_output = """# MyProject 1.0 (never)
@@ -350,7 +328,7 @@ No significant changes.
             }
         }
 
-        definitions = {[("misc", {"name": "Misc", "showcontent": False})]}
+        definitions = {"misc": {"name": "Misc", "showcontent": False}}
 
         expected_output = """MyProject 1.0 (never)
 =====================
@@ -398,7 +376,7 @@ Misc
             }
         }
 
-        definitions = {[("feature", {"name": "Features", "showcontent": True})]}
+        definitions = {"feature": {"name": "Features", "showcontent": True}}
 
         expected_output = """MyProject 1.0 (never)
 =====================
@@ -453,7 +431,7 @@ Features
             }
         }
 
-        definitions = {[("feature", {"name": "Features", "showcontent": True})]}
+        definitions = {"feature": {"name": "Features", "showcontent": True}}
 
         expected_output = """MyProject 1.0 (never)
 =====================

--- a/src/towncrier/test/test_format.py
+++ b/src/towncrier/test/test_format.py
@@ -2,8 +2,6 @@
 # See LICENSE for details.
 
 
-from collections import OrderedDict
-
 import pkg_resources
 
 from twisted.trial.unittest import TestCase
@@ -41,13 +39,13 @@ class FormatterTests(TestCase):
             },
         }
 
-        definitions = OrderedDict(
+        definitions = {
             [
                 ("feature", {"name": "Features", "showcontent": True}),
                 ("bugfix", {"name": "Bugfixes", "showcontent": True}),
                 ("misc", {"name": "Misc", "showcontent": False}),
             ]
-        )
+        }
 
         output = split_fragments(fragments, definitions)
 
@@ -58,7 +56,7 @@ class FormatterTests(TestCase):
         Basic functionality -- getting a bunch of news fragments and formatting
         them into a rST file -- works.
         """
-        fragments = OrderedDict(
+        fragments = {
             [
                 (
                     "",
@@ -79,15 +77,15 @@ class FormatterTests(TestCase):
                 ("Names", {}),
                 ("Web", {("3", "bugfix", 0): "Web fixed."}),
             ]
-        )
+        }
 
-        definitions = OrderedDict(
+        definitions = {
             [
                 ("feature", {"name": "Features", "showcontent": True}),
                 ("bugfix", {"name": "Bugfixes", "showcontent": True}),
                 ("misc", {"name": "Misc", "showcontent": False}),
             ]
-        )
+        }
 
         expected_output = """MyProject 1.0 (never)
 =====================
@@ -185,7 +183,7 @@ Bugfixes
         """
         Check formating of default markdown template.
         """
-        fragments = OrderedDict(
+        fragments = {
             [
                 (
                     "",
@@ -216,15 +214,15 @@ Bugfixes
                     },
                 ),
             ]
-        )
+        }
 
-        definitions = OrderedDict(
+        definitions = {
             [
                 ("feature", {"name": "Features", "showcontent": True}),
                 ("bugfix", {"name": "Bugfixes", "showcontent": True}),
                 ("misc", {"name": "Misc", "showcontent": False}),
             ]
-        )
+        }
 
         expected_output = """# MyProject 1.0 (never)
 
@@ -352,7 +350,7 @@ No significant changes.
             }
         }
 
-        definitions = OrderedDict([("misc", {"name": "Misc", "showcontent": False})])
+        definitions = {[("misc", {"name": "Misc", "showcontent": False})]}
 
         expected_output = """MyProject 1.0 (never)
 =====================
@@ -400,9 +398,7 @@ Misc
             }
         }
 
-        definitions = OrderedDict(
-            [("feature", {"name": "Features", "showcontent": True})]
-        )
+        definitions = {[("feature", {"name": "Features", "showcontent": True})]}
 
         expected_output = """MyProject 1.0 (never)
 =====================
@@ -457,9 +453,7 @@ Features
             }
         }
 
-        definitions = OrderedDict(
-            [("feature", {"name": "Features", "showcontent": True})]
-        )
+        definitions = {[("feature", {"name": "Features", "showcontent": True})]}
 
         expected_output = """MyProject 1.0 (never)
 =====================

--- a/src/towncrier/test/test_project.py
+++ b/src/towncrier/test/test_project.py
@@ -25,7 +25,6 @@ class VersionFetchingTests(TestCase):
         A str __version__ will be picked up.
         """
         temp = self.mktemp()
-        os.makedirs(temp)
         os.makedirs(os.path.join(temp, "mytestproj"))
 
         with open(os.path.join(temp, "mytestproj", "__init__.py"), "w") as f:
@@ -39,7 +38,6 @@ class VersionFetchingTests(TestCase):
         A tuple __version__ will be picked up.
         """
         temp = self.mktemp()
-        os.makedirs(temp)
         os.makedirs(os.path.join(temp, "mytestproja"))
 
         with open(os.path.join(temp, "mytestproja", "__init__.py"), "w") as f:
@@ -109,7 +107,6 @@ class VersionFetchingTests(TestCase):
         A __version__ of unknown type will lead to an exception.
         """
         temp = self.mktemp()
-        os.makedirs(temp)
         os.makedirs(os.path.join(temp, "mytestprojb"))
 
         with open(os.path.join(temp, "mytestprojb", "__init__.py"), "w") as f:
@@ -133,14 +130,12 @@ class VersionFetchingTests(TestCase):
         project_name = "mytestproj_already_installed_import"
 
         temp = self.mktemp()
-        os.makedirs(temp)
         os.makedirs(os.path.join(temp, project_name))
 
         with open(os.path.join(temp, project_name, "__init__.py"), "w") as f:
             f.write("__version__ = (1, 3, 12)")
 
         sys_path_temp = self.mktemp()
-        os.makedirs(sys_path_temp)
         os.makedirs(os.path.join(sys_path_temp, project_name))
 
         with open(os.path.join(sys_path_temp, project_name, "__init__.py"), "w") as f:
@@ -161,7 +156,6 @@ class VersionFetchingTests(TestCase):
         project_name = "mytestproj_only_installed"
 
         sys_path_temp = self.mktemp()
-        os.makedirs(sys_path_temp)
         os.makedirs(os.path.join(sys_path_temp, project_name))
 
         with open(os.path.join(sys_path_temp, project_name, "__init__.py"), "w") as f:

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -310,29 +310,18 @@ template = "towncrier:default.rst"
         """
         toml_content = textwrap.dedent(toml_content)
         expected = {
-            [
-                (
-                    "chore",
-                    {
-                        "name": "Other Tasks",
-                        "showcontent": False,
-                    },
-                ),
-                (
-                    "feat",
-                    {
-                        "name": "Feat",
-                        "showcontent": True,
-                    },
-                ),
-                (
-                    "fix",
-                    {
-                        "name": "Fix",
-                        "showcontent": True,
-                    },
-                ),
-            ]
+            "chore": {
+                "name": "Other Tasks",
+                "showcontent": False,
+            },
+            "feat": {
+                "name": "Feat",
+                "showcontent": True,
+            },
+            "fix": {
+                "name": "Fix",
+                "showcontent": True,
+            },
         }
 
         config = self.load_config_from_string(

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -202,7 +202,7 @@ orphan_prefix = "~"
             load_config(temp)
 
         self.assertEqual(
-            str(e.exception), "Towncrier does not have a template named 'foo'."
+            str(e.exception), "Towncrier does not have a template named 'foo.rst'."
         )
 
     def test_custom_types_as_tables_array_deprecated(self):

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -54,10 +54,12 @@ filename = "NEWS.md"
             )
 
         config = load_config(temp)
+
         self.assertEqual(config.filename, "NEWS.md")
         expected_template = pkg_resources.resource_filename(
             "towncrier", "templates/default.md"
         )
+
         self.assertEqual(config.template, expected_template)
 
     def test_explicit_template_extension(self):
@@ -78,6 +80,7 @@ template = "towncrier:default.rst"
             )
 
         config = load_config(temp)
+
         self.assertEqual(config.filename, "NEWS.md")
         expected_template = pkg_resources.resource_filename(
             "towncrier", "templates/default.rst"

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -1,7 +1,6 @@
 # Copyright (c) Amber Brown, 2015
 # See LICENSE for details.
 
-import collections as clt
 import os
 import textwrap
 
@@ -20,7 +19,6 @@ class TomlSettingsTests(TestCase):
         Test a "base config".
         """
         temp = self.mktemp()
-        os.makedirs(temp)
 
         with open(os.path.join(temp, "pyproject.toml"), "w") as f:
             f.write(
@@ -43,7 +41,6 @@ orphan_prefix = "~"
         extension, add .md rather than .rst.
         """
         temp = self.mktemp()
-        os.makedirs(temp)
 
         with open(os.path.join(temp, "pyproject.toml"), "w") as f:
             f.write(
@@ -68,7 +65,6 @@ filename = "NEWS.md"
         extension, don't change it.
         """
         temp = self.mktemp()
-        os.makedirs(temp)
 
         with open(os.path.join(temp, "pyproject.toml"), "w") as f:
             f.write(
@@ -92,7 +88,6 @@ template = "towncrier:default.rst"
         If the config file doesn't have the correct toml key, we error.
         """
         temp = self.mktemp()
-        os.makedirs(temp)
 
         with open(os.path.join(temp, "pyproject.toml"), "w") as f:
             f.write(
@@ -114,7 +109,6 @@ template = "towncrier:default.rst"
         single_file must be a bool.
         """
         temp = self.mktemp()
-        os.makedirs(temp)
 
         with open(os.path.join(temp, "pyproject.toml"), "w") as f:
             f.write(
@@ -136,7 +130,6 @@ template = "towncrier:default.rst"
         all_bullets must be a bool.
         """
         temp = self.mktemp()
-        os.makedirs(temp)
 
         with open(os.path.join(temp, "pyproject.toml"), "w") as f:
             f.write(
@@ -158,7 +151,6 @@ template = "towncrier:default.rst"
         singlefile is not accepted, single_file is.
         """
         temp = self.mktemp()
-        os.makedirs(temp)
 
         with open(os.path.join(temp, "pyproject.toml"), "w") as f:
             f.write(
@@ -180,7 +172,6 @@ template = "towncrier:default.rst"
         Towncrier prefers the towncrier.toml for autodetect over pyproject.toml.
         """
         temp = self.mktemp()
-        os.makedirs(temp)
 
         with open(os.path.join(temp, "towncrier.toml"), "w") as f:
             f.write(
@@ -210,7 +201,6 @@ template = "towncrier:default.rst"
         Towncrier will raise an exception saying when it can't find a template.
         """
         temp = self.mktemp()
-        os.makedirs(temp)
 
         with open(os.path.join(temp, "towncrier.toml"), "w") as f:
             f.write(
@@ -238,7 +228,6 @@ template = "towncrier:default.rst"
         from the Towncrier templates.
         """
         temp = self.mktemp()
-        os.makedirs(temp)
 
         with open(os.path.join(temp, "towncrier.toml"), "w") as f:
             f.write(
@@ -296,7 +285,7 @@ template = "towncrier:default.rst"
                 },
             ),
         ]
-        expected = clt.OrderedDict(expected)
+        expected = dict(expected)
         config = self.load_config_from_string(
             toml_content,
         )
@@ -308,8 +297,7 @@ template = "towncrier:default.rst"
         Custom fragment categories can be defined inside
         the toml config file using tables.
         """
-        test_project_path = self.mktemp()
-        os.makedirs(test_project_path)
+        self.mktemp()
         toml_content = """
         [tool.towncrier]
         package = "foobar"
@@ -321,31 +309,32 @@ template = "towncrier:default.rst"
         showcontent = false
         """
         toml_content = textwrap.dedent(toml_content)
-        expected = [
-            (
-                "chore",
-                {
-                    "name": "Other Tasks",
-                    "showcontent": False,
-                },
-            ),
-            (
-                "feat",
-                {
-                    "name": "Feat",
-                    "showcontent": True,
-                },
-            ),
-            (
-                "fix",
-                {
-                    "name": "Fix",
-                    "showcontent": True,
-                },
-            ),
-        ]
+        expected = {
+            [
+                (
+                    "chore",
+                    {
+                        "name": "Other Tasks",
+                        "showcontent": False,
+                    },
+                ),
+                (
+                    "feat",
+                    {
+                        "name": "Feat",
+                        "showcontent": True,
+                    },
+                ),
+                (
+                    "fix",
+                    {
+                        "name": "Fix",
+                        "showcontent": True,
+                    },
+                ),
+            ]
+        }
 
-        expected = clt.OrderedDict(expected)
         config = self.load_config_from_string(
             toml_content,
         )
@@ -359,7 +348,6 @@ template = "towncrier:default.rst"
         obtain the towncrier configuration.
         """
         test_project_path = self.mktemp()
-        os.makedirs(test_project_path)
         toml_path = os.path.join(test_project_path, "pyproject.toml")
         with open(toml_path, "w") as f:
             f.write(toml_content)

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -32,7 +32,7 @@ orphan_prefix = "~"
         self.assertEqual(config.package, "foobar")
         self.assertEqual(config.package_dir, ".")
         self.assertEqual(config.filename, "NEWS.rst")
-        self.assertEqual(config.underlines, ["=", "-", "~"])
+        self.assertEqual(config.underlines, ("=", "-", "~"))
         self.assertEqual(config.orphan_prefix, "~")
 
     def test_markdown(self):

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -3,11 +3,10 @@
 
 import os
 
-from textwrap import dedent
-
 from twisted.trial.unittest import TestCase
 
 from .._settings import ConfigError, load_config
+from .helpers import write
 
 
 class TomlSettingsTests(TestCase):
@@ -21,12 +20,18 @@ class TomlSettingsTests(TestCase):
         os.makedirs(project_dir)
 
         if pyproject_toml:
-            with open(os.path.join(project_dir, "pyproject.toml"), "w") as f:
-                f.write(dedent(pyproject_toml))
+            write(
+                os.path.join(project_dir, "pyproject.toml"),
+                pyproject_toml,
+                dedent=True,
+            )
 
         if towncrier_toml:
-            with open(os.path.join(project_dir, "towncrier.toml"), "w") as f:
-                f.write(dedent(towncrier_toml))
+            write(
+                os.path.join(project_dir, "towncrier.toml"),
+                towncrier_toml,
+                dedent=True,
+            )
 
         return project_dir
 

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -66,7 +66,7 @@ class TomlSettingsTests(TestCase):
 
         self.assertEqual(config.filename, "NEWS.md")
 
-        self.assertEqual(config.template, "towncrier.templates:default.md")
+        self.assertEqual(config.template, ("towncrier.templates", "default.md"))
 
     def test_explicit_template_extension(self):
         """
@@ -85,7 +85,7 @@ class TomlSettingsTests(TestCase):
         config = load_config(project_dir)
 
         self.assertEqual(config.filename, "NEWS.md")
-        self.assertEqual(config.template, "towncrier.templates:default.rst")
+        self.assertEqual(config.template, ("towncrier.templates", "default.rst"))
 
     def test_template_extended(self):
         """
@@ -103,7 +103,7 @@ class TomlSettingsTests(TestCase):
 
         config = load_config(project_dir)
 
-        self.assertEqual(config.template, "towncrier.templates:default.rst")
+        self.assertEqual(config.template, ("towncrier.templates", "default.rst"))
 
     def test_missing(self):
         """

--- a/src/towncrier/test/test_write.py
+++ b/src/towncrier/test/test_write.py
@@ -12,7 +12,7 @@ from twisted.trial.unittest import TestCase
 from .._builder import render_fragments, split_fragments
 from .._writer import append_to_newsfile
 from ..build import _main
-from .helpers import read_pkg_resource
+from .helpers import read_pkg_resource, write
 
 
 class WritingTests(TestCase):
@@ -175,13 +175,16 @@ Old text.
 """
 
         tempdir = self.mktemp()
-        os.makedirs(tempdir)
-
-        with open(os.path.join(tempdir, "NEWS.rst"), "w") as f:
-            f.write(
-                "Hello there! Here is some info.\n\n"
-                ".. towncrier release notes start\nOld text.\n"
-            )
+        write(
+            os.path.join(tempdir, "NEWS.rst"),
+            contents="""
+                Hello there! Here is some info.
+                
+                .. towncrier release notes start
+                Old text.
+            """,
+            dedent=True,
+        )
 
         fragments = split_fragments(fragments, definitions)
 

--- a/src/towncrier/test/test_write.py
+++ b/src/towncrier/test/test_write.py
@@ -75,6 +75,7 @@ Old text.
 """
 
         tempdir = self.mktemp()
+        os.makedirs(tempdir)
 
         with open(os.path.join(tempdir, "NEWS.rst"), "w") as f:
             f.write("Old text.\n")
@@ -177,6 +178,7 @@ Old text.
 """
 
         tempdir = self.mktemp()
+        os.makedirs(tempdir)
 
         with open(os.path.join(tempdir, "NEWS.rst"), "w") as f:
             f.write(
@@ -218,6 +220,7 @@ Old text.
         the start of the file.
         """
         tempdir = self.mktemp()
+        os.makedirs(tempdir)
 
         definitions = {}
         fragments = split_fragments(fragments={}, definitions=definitions)

--- a/src/towncrier/test/test_write.py
+++ b/src/towncrier/test/test_write.py
@@ -21,31 +21,22 @@ class WritingTests(TestCase):
 
     def test_append_at_top(self):
         fragments = {
-            [
-                (
-                    "",
-                    {
-                        [
-                            (("142", "misc", 0), ""),
-                            (("1", "misc", 0), ""),
-                            (("4", "feature", 0), "Stuff!"),
-                            (("4", "feature", 1), "Second Stuff!"),
-                            (("2", "feature", 0), "Foo added."),
-                            (("72", "feature", 0), "Foo added."),
-                        ]
-                    },
-                ),
-                ("Names", {}),
-                ("Web", {("3", "bugfix", 0): "Web fixed."}),
-            ]
+            "": {
+                ("142", "misc", 0): "",
+                ("1", "misc", 0): "",
+                ("4", "feature", 0): "Stuff!",
+                ("4", "feature", 1): "Second Stuff!",
+                ("2", "feature", 0): "Foo added.",
+                ("72", "feature", 0): "Foo added.",
+            },
+            "Names": {},
+            "Web": {("3", "bugfix", 0): "Web fixed."},
         }
 
         definitions = {
-            [
-                ("feature", {"name": "Features", "showcontent": True}),
-                ("bugfix", {"name": "Bugfixes", "showcontent": True}),
-                ("misc", {"name": "Misc", "showcontent": False}),
-            ]
+            "feature": {"name": "Features", "showcontent": True},
+            "bugfix": {"name": "Bugfixes", "showcontent": True},
+            "misc": {"name": "Misc", "showcontent": False},
         }
 
         expected_output = """MyProject 1.0 (never)
@@ -122,29 +113,22 @@ Old text.
         towncrier will add the version notes after it.
         """
         fragments = {
-            [
-                (
-                    "",
-                    {
-                        ("142", "misc", 0): "",
-                        ("1", "misc", 0): "",
-                        ("4", "feature", 0): "Stuff!",
-                        ("2", "feature", 0): "Foo added.",
-                        ("72", "feature", 0): "Foo added.",
-                        ("99", "feature", 0): "Foo! " * 100,
-                    },
-                ),
-                ("Names", {}),
-                ("Web", {("3", "bugfix", 0): "Web fixed."}),
-            ]
+            "": {
+                ("142", "misc", 0): "",
+                ("1", "misc", 0): "",
+                ("4", "feature", 0): "Stuff!",
+                ("2", "feature", 0): "Foo added.",
+                ("72", "feature", 0): "Foo added.",
+                ("99", "feature", 0): "Foo! " * 100,
+            },
+            "Names": {},
+            "Web": {("3", "bugfix", 0): "Web fixed."},
         }
 
         definitions = {
-            [
-                ("feature", {"name": "Features", "showcontent": True}),
-                ("bugfix", {"name": "Bugfixes", "showcontent": True}),
-                ("misc", {"name": "Misc", "showcontent": False}),
-            ]
+            "feature": {"name": "Features", "showcontent": True},
+            "bugfix": {"name": "Bugfixes", "showcontent": True},
+            "misc": {"name": "Misc", "showcontent": False},
         }
 
         expected_output = """Hello there! Here is some info.

--- a/src/towncrier/test/test_write.py
+++ b/src/towncrier/test/test_write.py
@@ -3,7 +3,6 @@
 
 import os
 
-from collections import OrderedDict
 from pathlib import Path
 from textwrap import dedent
 
@@ -21,11 +20,11 @@ class WritingTests(TestCase):
     maxDiff = None
 
     def test_append_at_top(self):
-        fragments = OrderedDict(
+        fragments = {
             [
                 (
                     "",
-                    OrderedDict(
+                    {
                         [
                             (("142", "misc", 0), ""),
                             (("1", "misc", 0), ""),
@@ -34,20 +33,20 @@ class WritingTests(TestCase):
                             (("2", "feature", 0), "Foo added."),
                             (("72", "feature", 0), "Foo added."),
                         ]
-                    ),
+                    },
                 ),
                 ("Names", {}),
                 ("Web", {("3", "bugfix", 0): "Web fixed."}),
             ]
-        )
+        }
 
-        definitions = OrderedDict(
+        definitions = {
             [
                 ("feature", {"name": "Features", "showcontent": True}),
                 ("bugfix", {"name": "Bugfixes", "showcontent": True}),
                 ("misc", {"name": "Misc", "showcontent": False}),
             ]
-        )
+        }
 
         expected_output = """MyProject 1.0 (never)
 =====================
@@ -85,7 +84,6 @@ Old text.
 """
 
         tempdir = self.mktemp()
-        os.mkdir(tempdir)
 
         with open(os.path.join(tempdir, "NEWS.rst"), "w") as f:
             f.write("Old text.\n")
@@ -123,7 +121,7 @@ Old text.
         If there is a comment with C{.. towncrier release notes start},
         towncrier will add the version notes after it.
         """
-        fragments = OrderedDict(
+        fragments = {
             [
                 (
                     "",
@@ -139,15 +137,15 @@ Old text.
                 ("Names", {}),
                 ("Web", {("3", "bugfix", 0): "Web fixed."}),
             ]
-        )
+        }
 
-        definitions = OrderedDict(
+        definitions = {
             [
                 ("feature", {"name": "Features", "showcontent": True}),
                 ("bugfix", {"name": "Bugfixes", "showcontent": True}),
                 ("misc", {"name": "Misc", "showcontent": False}),
             ]
-        )
+        }
 
         expected_output = """Hello there! Here is some info.
 
@@ -195,7 +193,6 @@ Old text.
 """
 
         tempdir = self.mktemp()
-        os.mkdir(tempdir)
 
         with open(os.path.join(tempdir, "NEWS.rst"), "w") as f:
             f.write(
@@ -237,7 +234,6 @@ Old text.
         the start of the file.
         """
         tempdir = self.mktemp()
-        os.mkdir(tempdir)
 
         definitions = {}
         fragments = split_fragments(fragments={}, definitions=definitions)

--- a/src/towncrier/test/test_write.py
+++ b/src/towncrier/test/test_write.py
@@ -179,7 +179,7 @@ Old text.
             os.path.join(tempdir, "NEWS.rst"),
             contents="""
                 Hello there! Here is some info.
-                
+
                 .. towncrier release notes start
                 Old text.
             """,

--- a/src/towncrier/test/test_write.py
+++ b/src/towncrier/test/test_write.py
@@ -177,7 +177,7 @@ Old text.
         tempdir = self.mktemp()
         write(
             os.path.join(tempdir, "NEWS.rst"),
-            contents="""
+            contents="""\
                 Hello there! Here is some info.
 
                 .. towncrier release notes start


### PR DESCRIPTION
# Description
Provides a default markdown template.

Towncrier will use this as the default template if the configured `filename` ends with `.md`. For any other filename, `default.rst` will continue to be used. For example:
```toml
filename = "CHANGES.md"
```

This is a simplification of earlier work in #439.

## Changes to `load.py`
In `load.py`, the Config dataclass now has defaults, rather than them being dispersed elsewhere in logic.

The `parse_toml` function has been reorganized for clarity (keeping the same functionality).

## Better configuration docs
The documentation for configuration settings was rewritten for completeness, better accuracy of defaults, and missing features.

It also better highlights different required settings for python vs non-python projects.

## Reference style link support
The only thing different in the markdown default template than the restructured text one is the ability to use markdown reference style links if the config is set to `issue_format = "[{issue}]: https://<bug tracker>/{issue}"`.

For example, with `issue_format = "[{issue}]: https://github.com/twisted/towncrier/issues/{issue}"`:

```markdown
...
### Features

- Foo added. ([2], [9], [72])
- More stuff ([3])
- Stuff! ([4])

[2]: https://github.com/twisted/towncrier/issues/2
[3]: https://github.com/twisted/towncrier/issues/3
[4]: https://github.com/twisted/towncrier/issues/4
[9]: https://github.com/twisted/towncrier/issues/9
[72]: https://github.com/twisted/towncrier/issues/72
```

This is why there's a new `issues_by_category` template context variable built and passed to the template.


# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
