### PR TITLE
build: if draft, return early

### DIFF
--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -245,38 +245,39 @@ def __main(
             err=to_err,
         )
         click.echo(content)
-    else:
-        click.echo("Writing to newsfile...", err=to_err)
-        news_file = config.filename
+        return
 
-        if config.single_file is False:
-            # The release notes for each version are stored in a separate file.
-            # The name of that file is generated based on the current version and project.
-            news_file = news_file.format(
-                name=project_name, version=project_version, project_date=project_date
-            )
+    click.echo("Writing to newsfile...", err=to_err)
+    news_file = config.filename
 
-        append_to_newsfile(
-            base_directory,
-            news_file,
-            config.start_string,
-            top_line,
-            content,
-            single_file=config.single_file,
+    if config.single_file is False:
+        # The release notes for each version are stored in a separate file.
+        # The name of that file is generated based on the current version and project.
+        news_file = news_file.format(
+            name=project_name, version=project_version, project_date=project_date
         )
 
-        click.echo("Staging newsfile...", err=to_err)
-        _git.stage_newsfile(base_directory, news_file)
+    append_to_newsfile(
+        base_directory,
+        news_file,
+        config.start_string,
+        top_line,
+        content,
+        single_file=config.single_file,
+    )
 
-        if should_remove_fragment_files(
-            fragment_filenames,
-            answer_yes,
-            answer_keep,
-        ):
-            click.echo("Removing news fragments...", err=to_err)
-            _git.remove_files(fragment_filenames)
+    click.echo("Staging newsfile...", err=to_err)
+    _git.stage_newsfile(base_directory, news_file)
 
-        click.echo("Done!", err=to_err)
+    if should_remove_fragment_files(
+        fragment_filenames,
+        answer_yes,
+        answer_keep,
+    ):
+        click.echo("Removing news fragments...", err=to_err)
+        _git.remove_files(fragment_filenames)
+
+    click.echo("Done!", err=to_err)
 
 
 def should_remove_fragment_files(


### PR DESCRIPTION
# Description

This is a small change to make the source easier to read. The condition that evaluates `draft` can return early, because there is no content after the else branch. As a result, ~25 lines can be unindented.

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [x] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
