### PR TITLE
build: add missing field 'help' to option 'date'

### DIFF
--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -78,7 +78,12 @@ def _validate_answer(ctx: Context, param: Option, value: bool) -> bool:
     default=None,
     help="Render the news fragments using given version.",
 )
-@click.option("--date", "project_date", default=None)
+@click.option(
+    "--date",
+    "project_date",
+    default=None,
+    help="Render the news fragments using the given date.",
+)
 @click.option(
     "--yes",
     "answer_yes",

--- a/src/towncrier/newsfragments/488.misc
+++ b/src/towncrier/newsfragments/488.misc
@@ -1,1 +1,1 @@
-Add missing field 'help' to CLI option 'date'
+Added help output for `build`'s `--date` option.

--- a/src/towncrier/newsfragments/488.misc
+++ b/src/towncrier/newsfragments/488.misc
@@ -1,0 +1,1 @@
+Add missing field 'help' to CLI option 'date'


### PR DESCRIPTION
# Description

CLI option 'date' is missing a description.

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [ ] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [x] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
