### PR TITLE
Drop black's target version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,6 @@ exclude = [
 
 
 [tool.black]
-target-version = ['py37']
 exclude = '''
 
 (


### PR DESCRIPTION
Black is smart enough to deduce it from requires-python.

Not sure if the rest is necessary, but at least it doesn't go out of date.
