### PR TITLE
Added pre-commit hooks (#498)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,16 @@
+- id: towncrier-check
+  name: towncrier-check
+  description: Check towncrier changelog updates
+  entry: towncrier --draft
+  pass_filenames: false
+  types: [text]
+  files: newsfragments/
+  language: python
+- id: towncrier-update
+  name: towncrier-update
+  description: Update changelog with towncrier
+  entry: towncrier
+  pass_filenames: false
+  args: ["--yes"]
+  files: newsfragments/
+  language: python

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ Reference
 
    cli
    configuration
+   pre-commit
    customization/index
 
 

--- a/docs/pre-commit.rst
+++ b/docs/pre-commit.rst
@@ -38,4 +38,3 @@ running ``update``:
           - id: towncrier-update
             files: $changelog\.d/
             args: ['--keep']
-

--- a/docs/pre-commit.rst
+++ b/docs/pre-commit.rst
@@ -1,11 +1,9 @@
 pre-commit
 ==========
 
-``towncrier`` can also be used in your `pre-commit <https://pre-commit.com/>`_ configuration (``.pre-commit-config.yaml``)
-to check and/or update your news fragments on commit or during CI processes.
+``towncrier`` can also be used in your `pre-commit <https://pre-commit.com/>`_ configuration (``.pre-commit-config.yaml``) to check and/or update your news fragments on commit or during CI processes.
 
-No additional configuration is needed in your ``towncrier`` configuration, the hook will read from the appropriate configuration
-files in your project.
+No additional configuration is needed in your ``towncrier`` configuration; the hook will read from the appropriate configuration files in your project.
 
 
 Examples
@@ -26,8 +24,7 @@ Usage with the default configuration
 Usage with custom configuration and directories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-News fragments are stored in ``changelog.d/`` in the root of the repository and we want to keep the news fragments when
-running ``update``:
+News fragments are stored in ``changelog.d/`` in the root of the repository and we want to keep the news fragments when running ``update``:
 
 .. code-block:: yaml
 

--- a/docs/pre-commit.rst
+++ b/docs/pre-commit.rst
@@ -1,0 +1,41 @@
+pre-commit
+==========
+
+``towncrier`` can also be used in your `pre-commit <https://pre-commit.com/>`_ configuration (``.pre-commit-config.yaml``)
+to check and/or update your news fragments on commit or during CI processes.
+
+No additional configuration is needed in your ``towncrier`` configuration, the hook will read from the appropriate configuration
+files in your project.
+
+
+Examples
+--------
+
+Usage with the default configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+    repos:
+      - repo: https://github.com/twisted/towncrier
+      - rev: 22.13.0  # run 'pre-commit autoupdate' to update
+      - hooks:
+          - id: towncrier-check
+
+
+Usage with custom configuration and directories
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+News fragments are stored in ``changelog.d/`` in the root of the repository and we want to keep the news fragments when
+running ``update``:
+
+.. code-block:: yaml
+
+    repos:
+      - repo: https://github.com/twisted/towncrier
+      - rev: 22.13.0  # run 'pre-commit autoupdate' to update
+      - hooks:
+          - id: towncrier-update
+            files: $changelog\.d/
+            args: ['--keep']
+

--- a/src/towncrier/newsfragments/498.feature
+++ b/src/towncrier/newsfragments/498.feature
@@ -1,0 +1,1 @@
+Added pre-commit hooks for checking and updating news in projects using pre-commit.


### PR DESCRIPTION
Added pre-commit hooks for checking and updating news in projects using pre-commit (#498)

* added ``towncrier-check`` to just check newly commited news fragments
* added ``towncrier-update`` to actually update the news
* added documentation section for ``pre-commit``

# Description

Added a pre-commit hooks for checking and updating news in projects using pre-commit, as suggested in my issue #498.

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [ ] Make sure changes are covered by existing or new tests.
* [ ] For at least one Python version, make sure local test run is green.
* [X] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [ ] Ensure `docs/tutorial.rst` is still up-to-date.
* [ ] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [ ] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
