### PR TITLE
No traceback on missing configuration with `towncrier check`

### DIFF
--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -86,7 +86,7 @@ def load_config_from_options(
         config = load_config_from_file(os.path.dirname(config_path), config_path)
 
     if config is None:
-        raise ConfigError(f"No configuration file found.\nLooked in: {base_directory}")
+        sys.exit(f"No configuration file found.\nLooked in: {base_directory}")
 
     return base_directory, config
 

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -12,6 +12,8 @@ from contextlib import ExitStack
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Mapping
 
+from click import ClickException
+
 from .._settings import fragment_types as ft
 
 
@@ -56,7 +58,7 @@ class Config:
     orphan_prefix: str
 
 
-class ConfigError(Exception):
+class ConfigError(ClickException):
     def __init__(self, *args: str, **kwargs: str):
         self.failing_option = kwargs.get("failing_option")
         super().__init__(*args)
@@ -86,7 +88,7 @@ def load_config_from_options(
         config = load_config_from_file(os.path.dirname(config_path), config_path)
 
     if config is None:
-        sys.exit(f"No configuration file found.\nLooked in: {base_directory}")
+        raise ConfigError(f"No configuration file found.\nLooked in: {base_directory}")
 
     return base_directory, config
 

--- a/src/towncrier/newsfragments/501.feature
+++ b/src/towncrier/newsfragments/501.feature
@@ -1,1 +1,3 @@
-Calling ``towncrier check`` without an existing configuration, will just show only an error message. In previous versions, a traceback was generated instead of the error message.
+Calling ``towncrier check`` without an existing configuration, will just show only an error message.
+
+In previous versions, a traceback was generated instead of the error message.

--- a/src/towncrier/newsfragments/501.feature
+++ b/src/towncrier/newsfragments/501.feature
@@ -1,1 +1,1 @@
-Calling ``towncrier check`` without an existing configuration, will just show only an error message. In previous versions, a traceback was also generated.
+Calling ``towncrier check`` without an existing configuration, will just show only an error message. In previous versions, a traceback was generated instead of the error message.

--- a/src/towncrier/newsfragments/501.feature
+++ b/src/towncrier/newsfragments/501.feature
@@ -1,1 +1,1 @@
-Don't raise an exception with ``towncrier check`` on missing configuration.
+Calling ``towncrier check`` without an existing configuration, will just show only an error message. In previous versions, a traceback was also generated.

--- a/src/towncrier/newsfragments/501.feature
+++ b/src/towncrier/newsfragments/501.feature
@@ -1,0 +1,1 @@
+Don't raise an exception with ``towncrier check`` on missing configuration.

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -8,8 +8,7 @@ from twisted.trial.unittest import TestCase
 
 from .._settings import ConfigError, load_config
 from .._shell import cli
-from .helpers import write, with_isolated_runner
-
+from .helpers import with_isolated_runner, write
 
 
 class TomlSettingsTests(TestCase):

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -7,9 +7,8 @@ from click.testing import CliRunner
 from twisted.trial.unittest import TestCase
 
 from .._settings import ConfigError, load_config
-
-from .helpers import write
 from .._shell import cli
+from .helpers import write
 
 
 class TomlSettingsTests(TestCase):

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -157,7 +157,9 @@ orphan_prefix = "~"
 
     def test_load_no_config(self):
         """
-        Check that no exception is raised if no config is found in the base directory.
+        Calling the root CLI without an existing configuration file in the base directory,
+        will exit with code 1 and an info message is sent to stdout.
+        No tracebeback is generated.
         """
         temp = self.mktemp()
         os.makedirs(temp)

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -8,7 +8,8 @@ from twisted.trial.unittest import TestCase
 
 from .._settings import ConfigError, load_config
 from .._shell import cli
-from .helpers import write
+from .helpers import write, with_isolated_runner
+
 
 
 class TomlSettingsTests(TestCase):
@@ -194,7 +195,8 @@ class TomlSettingsTests(TestCase):
         config = load_config(project_dir)
         self.assertEqual(config.package, "a")
 
-    def test_load_no_config(self):
+    @with_isolated_runner
+    def test_load_no_config(self, runner: CliRunner):
         """
         Calling the root CLI without an existing configuration file in the base directory,
         will exit with code 1 and an informative message is sent to standard output.
@@ -202,8 +204,8 @@ class TomlSettingsTests(TestCase):
         temp = self.mktemp()
         os.makedirs(temp)
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ["--dir", temp])
+        result = runner.invoke(cli, ("--dir", temp))
+
         self.assertEqual(
             result.output,
             f"No configuration file found.\nLooked in: {os.path.abspath(temp)}\n",

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -158,8 +158,7 @@ orphan_prefix = "~"
     def test_load_no_config(self):
         """
         Calling the root CLI without an existing configuration file in the base directory,
-        will exit with code 1 and an info message is sent to stdout.
-        No tracebeback is generated.
+        will exit with ConfigError.
         """
         temp = self.mktemp()
         os.makedirs(temp)

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -7,9 +7,11 @@ import textwrap
 
 from textwrap import dedent
 
+from click.testing import CliRunner
 from twisted.trial.unittest import TestCase
 
 from .._settings import ConfigError, load_config
+from .._shell import cli
 
 
 class TomlSettingsTests(TestCase):
@@ -152,6 +154,21 @@ orphan_prefix = "~"
 
         config = load_config(temp)
         self.assertEqual(config.package, "a")
+
+    def test_load_no_config(self):
+        """
+        Check that no exception is raised if no config is found in the base directory.
+        """
+        temp = self.mktemp()
+        os.makedirs(temp)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--dir", temp])
+        self.assertEqual(
+            result.output,
+            f"No configuration file found.\nLooked in: {os.path.abspath(temp)}\n",
+        )
+        self.assertEqual(result.exit_code, 1)
 
     def test_missing_template(self):
         """

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -197,7 +197,7 @@ class TomlSettingsTests(TestCase):
     def test_load_no_config(self):
         """
         Calling the root CLI without an existing configuration file in the base directory,
-        will exit with ConfigError.
+        will exit with code 1 and an informative message is sent to standard output.
         """
         temp = self.mktemp()
         os.makedirs(temp)


### PR DESCRIPTION
# Description
<!-- add a short summary if necessary; mention issue numbers -->

Fixes #336 

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [ ] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [ ] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
