### PR TITLE
#432 Use `importlib.metadata.version` to get the version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ requires-python = ">=3.8"
 dependencies = [
     "click",
     "importlib-resources>=5; python_version<'3.10'",
-    "importlib-metadata==4.6.*; python_version<'3.10'",
+    "importlib-metadata>=4.6; python_version<'3.10'",
     "incremental",
     "jinja2",
     "tomli; python_version<'3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ requires-python = ">=3.8"
 dependencies = [
     "click",
     "importlib-resources>=5; python_version<'3.10'",
+    "importlib-metadata=4.6.*; python_version<'3.10'",
     "incremental",
     "jinja2",
     "tomli; python_version<'3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ requires-python = ">=3.8"
 dependencies = [
     "click",
     "importlib-resources>=5; python_version<'3.10'",
-    "importlib-metadata=4.6.*; python_version<'3.10'",
+    "importlib-metadata==4.6.*; python_version<'3.10'",
     "incremental",
     "jinja2",
     "tomli; python_version<'3.11'",

--- a/src/towncrier/_project.py
+++ b/src/towncrier/_project.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 import sys
 
 from importlib import import_module
-from importlib.metadata import version as metadata_version
 from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as metadata_version
 from types import ModuleType
 
 from incremental import Version as IncrementalVersion

--- a/src/towncrier/_project.py
+++ b/src/towncrier/_project.py
@@ -13,6 +13,7 @@ from importlib import import_module
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as metadata_version
 from types import ModuleType
+from typing import Any
 
 from incremental import Version as IncrementalVersion
 
@@ -20,7 +21,7 @@ from incremental import Version as IncrementalVersion
 try:
     from importlib.metadata import packages_distributions
 except ImportError:
-    from importlib_metadata import packages_distributions
+    from importlib_metadata import packages_distributions  # type: ignore
 
 
 def _get_package(package_dir: str, package: str) -> ModuleType:
@@ -57,6 +58,8 @@ def _get_metadata_version(package: str) -> str | None:
 
 
 def get_version(package_dir: str, package: str) -> str:
+    version: Any
+
     # First try to get the version from the package metadata.
     if version := _get_metadata_version(package):
         return version

--- a/src/towncrier/_project.py
+++ b/src/towncrier/_project.py
@@ -45,6 +45,9 @@ def _get_package(package_dir: str, package: str) -> ModuleType:
 
 
 def _get_metadata_version(package: str) -> str | None:
+    """
+    Try to get the version from the package metadata.
+    """
     distributions = packages_distributions()
     distribution_names = distributions.get(package)
     if not distribution_names or len(distribution_names) != 1:
@@ -54,12 +57,19 @@ def _get_metadata_version(package: str) -> str | None:
 
 
 def get_version(package_dir: str, package: str) -> str:
+    """
+    Get the version of a package.
+
+    Try to extract the version from the distribution version metadata that matches
+    `package`, then fall back to looking for the package in `package_dir`.
+    """
     version: Any
 
     # First try to get the version from the package metadata.
     if version := _get_metadata_version(package):
         return version
 
+    # When no version if found, fall back to looking for the package in `package_dir`.
     module = _get_package(package_dir, package)
 
     version = getattr(module, "__version__", None)

--- a/src/towncrier/_project.py
+++ b/src/towncrier/_project.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import sys
 
 from importlib import import_module
-from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as metadata_version
 from types import ModuleType
 from typing import Any
@@ -51,10 +50,7 @@ def _get_metadata_version(package: str) -> str | None:
     if not distribution_names or len(distribution_names) != 1:
         # We can only determine the version if there is exactly one matching distribution.
         return None
-    try:
-        return metadata_version(distribution_names[0])
-    except PackageNotFoundError:
-        return None
+    return metadata_version(distribution_names[0])
 
 
 def get_version(package_dir: str, package: str) -> str:

--- a/src/towncrier/_project.py
+++ b/src/towncrier/_project.py
@@ -47,8 +47,8 @@ def _get_package(package_dir: str, package: str) -> ModuleType:
 def _get_metadata_version(package: str) -> str | None:
     distributions = packages_distributions()
     distribution_names = distributions.get(package)
-    if not len(distribution_names) == 1:
-        # We can't determine the version if there are multiple distributions.
+    if not distribution_names or not len(distribution_names) == 1:
+        # We can only determine the version if there is exactly one matching distribution.
         return None
     try:
         return metadata_version(distribution_names[0])

--- a/src/towncrier/_project.py
+++ b/src/towncrier/_project.py
@@ -47,7 +47,7 @@ def _get_package(package_dir: str, package: str) -> ModuleType:
 def _get_metadata_version(package: str) -> str | None:
     distributions = packages_distributions()
     distribution_names = distributions.get(package)
-    if not distribution_names or not len(distribution_names) == 1:
+    if not distribution_names or len(distribution_names) != 1:
         # We can only determine the version if there is exactly one matching distribution.
         return None
     try:

--- a/src/towncrier/_project.py
+++ b/src/towncrier/_project.py
@@ -17,9 +17,9 @@ from typing import Any
 from incremental import Version as IncrementalVersion
 
 
-try:
+if sys.version_info >= (3, 10):
     from importlib.metadata import packages_distributions
-except ImportError:
+else:
     from importlib_metadata import packages_distributions  # type: ignore
 
 

--- a/src/towncrier/_project.py
+++ b/src/towncrier/_project.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import sys
 
 from importlib import import_module
+from importlib.metadata import version as metadata_version
+from importlib.metadata import PackageNotFoundError
 from types import ModuleType
 
 from incremental import Version as IncrementalVersion
@@ -39,8 +41,10 @@ def _get_package(package_dir: str, package: str) -> ModuleType:
 
 def get_version(package_dir: str, package: str) -> str:
     module = _get_package(package_dir, package)
-
-    version = getattr(module, "__version__", None)
+    try:
+        version = metadata_version(f"{module}")
+    except PackageNotFoundError:
+        version = getattr(module, "__version__", None)
 
     if not version:
         raise Exception("No __version__, I don't know how else to look")

--- a/src/towncrier/_project.py
+++ b/src/towncrier/_project.py
@@ -76,7 +76,7 @@ def get_version(package_dir: str, package: str) -> str:
 
     if not version:
         raise Exception(
-            f"No __version__ or metadata version info for the {package} package."
+            f"No __version__ or metadata version info for the '{package}' package."
         )
 
     if isinstance(version, str):

--- a/src/towncrier/newsfragments/432.feature.rst
+++ b/src/towncrier/newsfragments/432.feature.rst
@@ -1,0 +1,1 @@
+Inferring the version of a Python package now tries to use the metadata of the installed package before importing the package explicitly (which only looks for ``[package].__version__``).

--- a/src/towncrier/test/test_project.py
+++ b/src/towncrier/test/test_project.py
@@ -72,6 +72,13 @@ class VersionFetchingTests(TestCase):
         self.assertEqual(metadata_version("towncrier"), version)
         self.assertEqual("towncrier", name)
 
+    def test_version_from_metadata(self):
+        """
+        A version from package metadata is picked up.
+        """
+        version = get_version(".", "towncrier")
+        self.assertEqual(metadata_version("towncrier"), version)
+
     def _setup_missing(self):
         """
         Create a minimalistic project with missing metadata in a temporary

--- a/src/towncrier/test/test_project.py
+++ b/src/towncrier/test/test_project.py
@@ -100,10 +100,11 @@ class VersionFetchingTests(TestCase):
         tmp_dir = self._setup_missing()
 
         with self.assertRaises(Exception) as e:
-            get_version(tmp_dir, "not_here")
+            # The 'missing' package has no __version__ string.
+            get_version(tmp_dir, "missing")
 
         self.assertEqual(
-            ("No __version__ or metadata version info for the 'not_here' package.",),
+            ("No __version__ or metadata version info for the 'missing' package.",),
             e.exception.args,
         )
 

--- a/src/towncrier/test/test_project.py
+++ b/src/towncrier/test/test_project.py
@@ -94,7 +94,8 @@ class VersionFetchingTests(TestCase):
             get_version(tmp_dir, "missing")
 
         self.assertEqual(
-            ("No __version__, I don't know how else to look",), e.exception.args
+            ("No __version__ or metadata version info for the missing package.",),
+            e.exception.args,
         )
 
     def test_missing_version_project_name(self):

--- a/src/towncrier/test/test_project.py
+++ b/src/towncrier/test/test_project.py
@@ -100,10 +100,10 @@ class VersionFetchingTests(TestCase):
         tmp_dir = self._setup_missing()
 
         with self.assertRaises(Exception) as e:
-            get_version(tmp_dir, "missing")
+            get_version(tmp_dir, "not_here")
 
         self.assertEqual(
-            ("No __version__ or metadata version info for the missing package.",),
+            ("No __version__ or metadata version info for the 'not_here' package.",),
             e.exception.args,
         )
 


### PR DESCRIPTION
# Description
This PR updates the `get_version()` method in `src/towncrier/_project.py` to use `importlib.metadata.version()` [Fixes #432]

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [ ] Make sure changes are covered by existing or new tests.
* [ ] For at least one Python version, make sure local test run is green.
* [ ] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [ ] Ensure `docs/tutorial.rst` is still up-to-date.
* [ ] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [ ] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
