### PR TITLE
Update configuration.rst to fix broken link to quickstart.html

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2,7 +2,7 @@ Configuration Reference
 =======================
 
 ``towncrier`` has many knobs and switches you can use, to customize it to your project's needs.
-The setup in the `Quick Start <quickstart.html>`_ doesn't touch on many, but this document will detail each of these options for you!
+The setup in the `Tutorial <tutorial.html>`_ doesn't touch on many, but this document will detail each of these options for you!
 
 For how to perform common customization tasks, see `Customization <customization/index.html>`_.
 

--- a/src/towncrier/newsfragments/504.doc
+++ b/src/towncrier/newsfragments/504.doc
@@ -1,0 +1,1 @@
+Update Quick Start in configuration.html to link to tutorial instead.

--- a/src/towncrier/newsfragments/504.doc
+++ b/src/towncrier/newsfragments/504.doc
@@ -1,1 +1,1 @@
-Update Quick Start in configuration.html to link to tutorial instead.
+Update link to Quick Start in configuration.html to point to Tutorial instead.


### PR DESCRIPTION




# Description

https://towncrier.readthedocs.io/en/stable/configuration.html contains the current broken link to https://towncrier.readthedocs.io/en/stable/quickstart.html on the first paragraph, I believe this should likely point to the tutorial instead.

<!-- add a short summary if necessary; mention issue numbers -->



# Checklist

I don't believe i need to tick most of these as this is a documentation change:

<!-- add a "X" inside the brackets to confirm -->
* [ ] Make sure changes are covered by existing or new tests.
* [ ] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [ ] Ensure `docs/tutorial.rst` is still up-to-date.
* [ ] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [ ] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
