### PR TITLE
Remove click_default_group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
 requires-python = ">=3.7"
 dependencies = [
     "click",
-    "click-default-group",
     "importlib-resources>1.3; python_version<'3.9'",
     "incremental",
     "jinja2",
@@ -141,11 +140,6 @@ strict = true
 # 2022-09-04: Trial's API isn't annotated yet, which limits the usefulness of type-checking
 #             the unit tests. Therefore they have not been annotated yet.
 exclude = '^src/towncrier/test/test_.*\.py$'
-
-[[tool.mypy.overrides]]
-module = 'click_default_group'
-# 2022-09-04: This library has no type annotations.
-ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = 'incremental'

--- a/src/towncrier/_shell.py
+++ b/src/towncrier/_shell.py
@@ -11,17 +11,16 @@ from __future__ import annotations
 
 import click
 
-from click_default_group import DefaultGroup
-
 from ._version import __version__
 from .build import _main as _build_cmd
 from .check import _main as _check_cmd
 from .create import _main as _create_cmd
 
 
-@click.group(cls=DefaultGroup, default="build", default_if_no_args=True)
+@click.group(invoke_without_command=True, params=_build_cmd.params)
 @click.version_option(__version__.public())
-def cli() -> None:
+@click.pass_context
+def cli(ctx, *args, **kwargs) -> None:
     """
     Towncrier is a utility to produce useful, summarised news files for your project.
     Rather than reading the Git history as some newer tools to produce it, or having
@@ -38,7 +37,8 @@ def cli() -> None:
     a collection of these fragments, towncrier can produce a digest of the changes
     which is valuable to those who may wish to use the software.
     """
-    pass
+    if not ctx.invoked_subcommand:
+        ctx.invoke(_build_cmd, *args, **kwargs)
 
 
 cli.add_command(_build_cmd)


### PR DESCRIPTION
Here's a quick take of replacing this small and old package with just what click provides out of the box.

This does change the current `--help` output from
```
Usage: towncrier [OPTIONS] COMMAND [ARGS]...

  Towncrier is a utility [...]

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  build*  Build a combined news file from news fragment.
  check   Check for new fragments on a branch.
  create  Create a new news fragment.
```
to 
```
Usage: towncrier [OPTIONS] COMMAND [ARGS]...

  Towncrier is a utility [...]

Options:
  --draft             Render the news fragments to standard output. Don't
                      write to files, don't check versions.
  --config FILE_PATH  Pass a custom config file at FILE_PATH. Default:
                      towncrier.toml or pyproject.toml file, if both files
                      exist, the first will take precedence.
  --dir PATH          Build fragment in directory. Default to current
                      directory.
  --name TEXT         Pass a custom project name.
  --version TEXT      Render the news fragments using given version.
  --date TEXT         Render the news fragments using the given date.
  --yes               Do not ask for confirmation to remove news fragments.
  --keep              Do not ask for confirmations. But keep news fragments.
  --version           Show the version and exit.
  --help              Show this message and exit.

Commands:
  build   Build a combined news file from news fragment.
  check   Check for new fragments on a branch.
  create  Create a new news fragment.
```

# Description
<!-- add a short summary if necessary; mention issue numbers -->

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [ ] Make sure changes are covered by existing or new tests.
* [ ] For at least one Python version, make sure local test run is green.
* [ ] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [ ] Ensure `docs/tutorial.rst` is still up-to-date.
* [ ] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [ ] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
