### PR TITLE
Provide a friendly message if version option is required

### DIFF
--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -153,15 +153,15 @@ def __main(
 
     if project_version is None:
         project_version = config.version
-        if project_version is None:
-            if not config.package:
-                raise UsageError(
-                    "'--version' is required since the config file does "
-                    "not contain 'version' or 'package'."
-                )
-            project_version = get_version(
-                os.path.join(base_directory, config.package_dir), config.package
-            ).strip()
+    if project_version is None:
+        if not config.package:
+            raise UsageError(
+                "'--version' is required since the config file does "
+                "not contain 'version' or 'package'."
+            )
+        project_version = get_version(
+            os.path.join(base_directory, config.package_dir), config.package
+        ).strip()
 
     click.echo("Loading template...", err=to_err)
     if isinstance(config.template, tuple):

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -15,7 +15,7 @@ from datetime import date
 
 import click
 
-from click import Context, Option
+from click import Context, Option, UsageError
 
 from towncrier import _git
 
@@ -151,6 +151,18 @@ def __main(
     base_directory, config = load_config_from_options(directory, config_file)
     to_err = draft
 
+    if project_version is None:
+        project_version = config.version
+        if project_version is None:
+            if not config.package:
+                raise UsageError(
+                    "'--version' is required since the config file does "
+                    "not contain 'version' or 'package'."
+                )
+            project_version = get_version(
+                os.path.join(base_directory, config.package_dir), config.package
+            ).strip()
+
     click.echo("Loading template...", err=to_err)
     if isinstance(config.template, tuple):
         template = resources.read_text(*config.template)
@@ -181,13 +193,6 @@ def __main(
     fragments = split_fragments(
         fragment_contents, config.types, all_bullets=config.all_bullets
     )
-
-    if project_version is None:
-        project_version = config.version
-        if project_version is None:
-            project_version = get_version(
-                os.path.join(base_directory, config.package_dir), config.package
-            ).strip()
 
     if project_name is None:
         project_name = config.name

--- a/src/towncrier/newsfragments/507.misc
+++ b/src/towncrier/newsfragments/507.misc
@@ -1,1 +1,1 @@
-Provide a friendly message if --version option is required (for non-Python projects that don't explicitly provide the version in the config)
+A friendly message is now provided, when it's necessary to pass the ``--version`` option explicitly.

--- a/src/towncrier/newsfragments/507.misc
+++ b/src/towncrier/newsfragments/507.misc
@@ -1,0 +1,1 @@
+Provide a friendly message if --version option is required (for non-Python projects that don't explicitly provide the version in the config)

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -517,9 +517,10 @@ class TestCli(TestCase):
         If the configuration file doesn't specify a version or a package, the version
         option is required.
         """
-        with open("towncrier.toml", "w") as f:
-            f.write("[tool.towncrier]")
+        write("towncrier.toml", "[tool.towncrier]")
+
         result = runner.invoke(_main, ["--draft"], catch_exceptions=False)
+
         self.assertEqual(2, result.exit_code)
         self.assertIn("Error: '--version' is required", result.output)
 

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -511,6 +511,18 @@ class TestCli(TestCase):
         self.assertEqual(1, result.exit_code, result.output)
         self.assertTrue(result.output.startswith("No configuration file found."))
 
+    @with_isolated_runner
+    def test_needs_version(self, runner: CliRunner):
+        """
+        If the configuration file doesn't specify a version or a package, the version
+        option is required.
+        """
+        with open("towncrier.toml", "w") as f:
+            f.write("[tool.towncrier]")
+        result = runner.invoke(_main, ["--draft"], catch_exceptions=False)
+        self.assertEqual(2, result.exit_code)
+        self.assertIn("Error: '--version' is required", result.output)
+
     def test_projectless_changelog(self):
         """In which a directory containing news files is built into a changelog
 


### PR DESCRIPTION
# Description
Fixes #445

For non-python projects that don't explicitly provide the version in the config, the `--version` option is required. So let the user know rather than raising an obscure exception.

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [x] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
