### PR TITLE
Bump python version for ReadTheDocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,8 +7,12 @@ sphinx:
 # We don't need PDF and epub for the docs.
 formats: []
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: "3.8"
   system_packages: False
   install:
     - method: pip

--- a/src/towncrier/newsfragments/509.bugfix
+++ b/src/towncrier/newsfragments/509.bugfix
@@ -1,0 +1,1 @@
+Fix the ReadTheDocs build for ``towncrier`` which was broken due to the python version in use being 3.8. Upgrade to 3.11.


### PR DESCRIPTION
# Description
<!-- add a short summary if necessary; mention issue numbers -->

Aims to fix the Readthedocs build. See #501 

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [ ] Ensure `docs/tutorial.rst` is still up-to-date.
* [ ] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [ ] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
