### PR TITLE
Fix typo in pre-commit docs

### DIFF
--- a/docs/pre-commit.rst
+++ b/docs/pre-commit.rst
@@ -16,8 +16,8 @@ Usage with the default configuration
 
     repos:
       - repo: https://github.com/twisted/towncrier
-      - rev: 22.13.0  # run 'pre-commit autoupdate' to update
-      - hooks:
+        rev: 22.13.0  # run 'pre-commit autoupdate' to update
+        hooks:
           - id: towncrier-check
 
 
@@ -30,8 +30,8 @@ News fragments are stored in ``changelog.d/`` in the root of the repository and 
 
     repos:
       - repo: https://github.com/twisted/towncrier
-      - rev: 22.13.0  # run 'pre-commit autoupdate' to update
-      - hooks:
+        rev: 22.13.0  # run 'pre-commit autoupdate' to update
+        hooks:
           - id: towncrier-update
             files: $changelog\.d/
             args: ['--keep']

--- a/src/towncrier/newsfragments/512.doc
+++ b/src/towncrier/newsfragments/512.doc
@@ -1,0 +1,1 @@
+Fix typos in the Pre-Commit docs.


### PR DESCRIPTION
# Description
The previous examples won't install/run in pre-commit. The repo is missing the `hooks` and `rev` keys . This changes it so the hooks and rev keys are in the repo block.

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [x] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
