### PR TITLE
Drop Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - name: CPython 3.7
-            action: 3.7
           - name: CPython 3.8
             action: 3.8
           - name: CPython 3.9
@@ -70,8 +68,6 @@ jobs:
             action: '3.10'
           - name: CPython 3.11
             action: '3.11'
-          - name: PyPy 3.7
-            action: pypy3.7
           - name: PyPy 3.8
             action: pypy3.8
         task:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     rev: v3.4.0
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Rather than reading the Git history, or having one single file which developers 
 
 Used by `Twisted <https://github.com/twisted/twisted>`_, `pytest <https://github.com/pytest-dev/pytest/>`_, `pip <https://github.com/pypa/pip/>`_, `BuildBot <https://github.com/buildbot/buildbot>`_, and `attrs <https://github.com/python-attrs/attrs>`_, among others.
 
-While the command line tool ``towncrier`` works on Python 3.7+ only, as long as you don't use any Python-specific affordances (like auto-detection of the project version), it is usable with **any project type** on **any platform**.
+While the command line tool ``towncrier`` requires Python to run, as long as you don't use any Python-specific affordances (like auto-detection of the project version), it is usable with **any project type** on **any platform**.
 
 
 Philosophy

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ def pre_commit(session: nox.Session) -> None:
     session.run("pre-commit", "run", "--all-files", "--show-diff-on-failure")
 
 
-@nox.session(python=["pypy3.7", "pypy3.8", "3.7", "3.8", "3.9", "3.10", "3.11"])
+@nox.session(python=["pypy3.8", "3.8", "3.9", "3.10", "3.11"])
 def tests(session: nox.Session) -> None:
     session.install("Twisted", "coverage[toml]")
     posargs = list(session.posargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -27,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "click",
     "click-default-group",

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -11,20 +11,12 @@ import sys
 
 from contextlib import ExitStack
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Mapping, Sequence
+from typing import Any, Literal, Mapping, Sequence
 
 from click import ClickException
 
 from .._settings import fragment_types as ft
 
-
-if TYPE_CHECKING:
-    # We only use Literal for type-checking and Mypy always brings its own
-    # typing_extensions so this is safe without further dependencies.
-    if sys.version_info < (3, 8):
-        from typing_extensions import Literal
-    else:
-        from typing import Literal
 
 if sys.version_info < (3, 10):
     import importlib_resources as resources

--- a/src/towncrier/newsfragments/521.removal
+++ b/src/towncrier/newsfragments/521.removal
@@ -1,0 +1,1 @@
+The support for Python 3.7 has been dropped.


### PR DESCRIPTION
As discussed, this drops Python 3.7 that goes EOL on 2023-06-27.