### PR TITLE
prevent universal_newlines modifying --draft output

### DIFF
--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -258,7 +258,8 @@ def __main(
             "What is seen below is what would be written.\n",
             err=to_err,
         )
-        click.echo(content)
+        # output as bytes to prevent universal_newlines modifying content #453
+        click.echo(content.encode("utf8"))
         return
 
     click.echo("Writing to newsfile...", err=to_err)


### PR DESCRIPTION
# Description

Fixes #524 

News fragments are read in binary mode, so on Windows they keep their `\r\n` newlines. When these are echoed to the console in `--draft` mode, Python's universal newlines support converts the `\n` to `os.linesep` (`\r\n`), leaving them as `\r\r\n`. If this output is then read by Python again (in text mode), that same newline support converts both `\r` and `\r\n` into `\n`, causing all newlines to be doubled up (`\n\n`). This commit echoes the `--draft` output as utf8 encoded `bytes` rather than a `str` to prevent this from happening. This also matches the behaviour of writing to a newsfile in non-draft mode.

@adiroiban please let me know what tests (if any) you think would be appropriate for this change and I will add them. I will also add a news fragment detailing the change if you are minded to accept the change.

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [ ] Make sure changes are covered by existing or new tests.
* [ ] For at least one Python version, make sure local test run is green.
* [ ] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [X] Ensure `docs/tutorial.rst` is still up-to-date.
* [X] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [X] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
