### PR TITLE
use markdown default template in markdown docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,6 @@ build:
     python: "3.11"
 
 python:
-  system_packages: False
   install:
     - method: pip
       path: .

--- a/docs/markdown.rst
+++ b/docs/markdown.rst
@@ -21,7 +21,6 @@ Put the following into your ``pyproject.toml`` or ``towncrier.toml``:
    filename = "CHANGELOG.md"
    start_string = "<!-- towncrier release notes start -->\n"
    underlines = ["", "", ""]
-   template = "changelog.d/changelog_template.jinja"
    title_format = "## [{version}](https://github.com/twisted/my-project/tree/{version}) - {project_date}"
    issue_format = "[#{issue}](https://github.com/twisted/my-project/issues/{issue})"
 
@@ -57,32 +56,11 @@ Put the following into your ``pyproject.toml`` or ``towncrier.toml``:
 
 
 
-Next create the news fragment directory and the news file template:
+Next create the news fragment directory:
 
 .. code-block:: console
 
    $ mkdir changelog.d
-
-And put the following into ``changelog.d/changelog_template.jinja``:
-
-.. code-block:: jinja
-
-   {% if sections[""] %}
-   {% for category, val in definitions.items() if category in sections[""] %}
-
-   ### {{ definitions[category]['name'] }}
-
-   {% for text, values in sections[""][category].items() %}
-   - {{ text }} {{ values|join(', ') }}
-   {% endfor %}
-
-   {% endfor %}
-   {% else %}
-   No significant changes.
-
-
-   {% endif %}
-
 
 Next, create the news file with an explanatory header::
 
@@ -138,32 +116,32 @@ After running ``towncrier build --yes --version 1.0.0`` (you can ignore the Git 
 
    ### Security
 
-   - Fixed a security issue! [#6](https://github.com/twisted/my-project/issues/6), [#7](https://github.com/twisted/my-project/issues/7)
+   - Fixed a security issue! ([#6](https://github.com/twisted/my-project/issues/6), [#7](https://github.com/twisted/my-project/issues/7))
 
 
    ### Removed
 
-   - Removed a square feature! [#4](https://github.com/twisted/my-project/issues/4)
+   - Removed a square feature! ([#4](https://github.com/twisted/my-project/issues/4))
 
 
    ### Deprecated
 
-   - Deprecated a module! [#3](https://github.com/twisted/my-project/issues/3)
+   - Deprecated a module! ([#3](https://github.com/twisted/my-project/issues/3))
 
 
    ### Added
 
-   - Added a cool feature! [#1](https://github.com/twisted/my-project/issues/1)
+   - Added a cool feature! ([#1](https://github.com/twisted/my-project/issues/1))
 
 
    ### Changed
 
-   - Changed a behavior! [#2](https://github.com/twisted/my-project/issues/2)
+   - Changed a behavior! ([#2](https://github.com/twisted/my-project/issues/2))
 
 
    ### Fixed
 
-   - Fixed a bug! [#5](https://github.com/twisted/my-project/issues/5)
+   - Fixed a bug! ([#5](https://github.com/twisted/my-project/issues/5))
    - A fix without an issue number!
 
 Pretty close, so this concludes this guide!

--- a/src/towncrier/newsfragments/545.doc
+++ b/src/towncrier/newsfragments/545.doc
@@ -1,0 +1,1 @@
+The markdown docs now use the default markdown template rather than a simpler custom one.


### PR DESCRIPTION
# Description
Closes #545

Uses the default markdown templates introduced in #483 in the markdown docs rather than specifying a custom template.

One option for resolving #545 - thought I'd provide a PR as it was simple, but happy if you want to resolve in a different way (e.g. an explicit block in the docs discussing the default markdown template vs the custom one currently used).

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [X] Make sure changes are covered by existing or new tests.
* [X] For at least one Python version, make sure local test run is green.
* [X] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [X] Ensure `docs/tutorial.rst` is still up-to-date.
* [X] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [X] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
