### PR TITLE
Config location separate from directory containing news file and fragments

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -12,7 +12,8 @@ The following options can be passed to all of the commands that explained below:
 
 .. option:: --dir PATH
 
-   Build fragment in ``PATH``.
+   The command is executed relative to ``PATH``.
+   For instance with the default config news fragments are checked and added in ``PATH/newsfragments`` and the news file is built in ``PATH/NEWS.rst``.
 
    Default: current directory.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -51,12 +51,13 @@ Top level keys
     The directory storing your news fragments.
 
     For Python projects that provide a ``package`` key, the default is a ``newsfragments`` directory within the package.
-    Otherwise the default is a ``newsfragments`` directory relative to the configuration file.
+    Otherwise the default is a ``newsfragments`` directory relative to either the directory passed as ``--dir`` or (by default) the configuration file.
 
 ``filename``
     The filename of your news file.
 
     ``"NEWS.rst"`` by default.
+    Its location is determined the same way as the location of the directory storing the news fragments.
 
 ``template``
     Path to the template for generating the news file.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Narrative
 
    tutorial
    markdown
+   monorepo
 
 
 Reference

--- a/docs/monorepo.rst
+++ b/docs/monorepo.rst
@@ -1,0 +1,52 @@
+Multiple Projects Share One Config (Monorepo)
+=============================================
+
+Several projects may have independent release notes with the same format.
+For instance packages in a monorepo.
+Here's how you can use towncrier to set this up.
+
+Below is a minimal example:
+
+.. code-block:: text
+
+  repo
+  ├── project_a
+  │   ├── newsfragments
+  │   │   └── 123.added
+  │   ├── project_a
+  │   │   └── __init__.py
+  │   └── NEWS.rst
+  ├── project_b
+  │   ├── newsfragments
+  │   │   └── 120.bugfix
+  │   ├── project_b
+  │   │   └── __init__.py
+  │   └── NEWS.rst
+  └── towncrier.toml
+
+The ``towncrier.toml`` looks like this:
+
+.. code-block:: toml
+
+  [tool.towncrier]
+  # It's important to keep these config fields empty
+  # because we have more than one package/name to manage.
+  package = ""
+  name = ""
+
+Now to add a fragment:
+
+.. code-block:: console
+
+   towncrier create --config towncrier.toml --dir project_a  124.added
+
+This should create a file at ``project_a/newsfragments/124.added``.
+
+To build the news file for the same project:
+
+.. code-block:: console
+
+   towncrier build --config towncrier.toml --dir project_a --version 1.5
+
+Note that we must explicitly pass ``--version``, there is no other way to get the version number.
+The ``towncrier.toml`` can only contain one version number and the ``package`` field is of no use for the same reason.

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -175,7 +175,9 @@ def __main(
     click.echo("Finding news fragments...", err=to_err)
 
     if config.directory is not None:
-        fragment_base_directory = os.path.abspath(config.directory)
+        fragment_base_directory = os.path.abspath(
+            os.path.join(base_directory, config.directory)
+        )
         fragment_directory = None
     else:
         fragment_base_directory = os.path.abspath(

--- a/src/towncrier/check.py
+++ b/src/towncrier/check.py
@@ -93,9 +93,7 @@ def __main(
         )
         sys.exit(0)
 
-    files = {
-        os.path.normpath(os.path.join(base_directory, path)) for path in files_changed
-    }
+    files = {os.path.abspath(path) for path in files_changed}
 
     click.echo("Looking at these files:")
     click.echo("----")
@@ -109,7 +107,9 @@ def __main(
         sys.exit(0)
 
     if config.directory:
-        fragment_base_directory = os.path.abspath(config.directory)
+        fragment_base_directory = os.path.abspath(
+            os.path.join(base_directory, config.directory)
+        )
         fragment_directory = None
     else:
         fragment_base_directory = os.path.abspath(
@@ -118,7 +118,7 @@ def __main(
         fragment_directory = "newsfragments"
 
     fragments = {
-        os.path.normpath(path)
+        os.path.abspath(path)
         for path in find_fragments(
             fragment_base_directory,
             config.sections,

--- a/src/towncrier/newsfragments/548.feature
+++ b/src/towncrier/newsfragments/548.feature
@@ -1,2 +1,2 @@
-Full support for monorepo-style setup.
-One project with multiple independent news files that share the same towncrier config.
+Initial support was added for monorepo-style setup.
+One project with multiple independent news files stored in separate sub-directories, that share the same towncrier config.

--- a/src/towncrier/newsfragments/548.feature
+++ b/src/towncrier/newsfragments/548.feature
@@ -1,0 +1,2 @@
+Full support for monorepo-style setup.
+One project with multiple independent news files that share the same towncrier config.

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -146,11 +146,12 @@ class TestCli(TestCase):
     @with_isolated_runner
     def test_in_different_dir_with_nondefault_newsfragments_directory(self, runner):
         """
-        Config location differs from the base directory for news file and fragments.
-
-        This is useful when multiple projects share one towncrier configuration.
-        The default `newsfragments` setting already supports this scenario so here
-        we test that custom settings also do.
+        Using the `--dir` CLI argument, the NEWS file can
+        be generated in a sub-directory from fragments
+        that are relatives to that sub-directory.
+        
+        The path passed to `--dir` becomes the
+        working directory.
         """
         Path("pyproject.toml").write_text(
             "[tool.towncrier]\n" + 'directory = "changelog.d"\n'

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1363,7 +1363,8 @@ Deprecations and Removals
         Path("pyproject.toml").write_text(
             # Important to customize `config.directory` because the default
             # already supports this scenario.
-            "[tool.towncrier]\n" + 'directory = "changelog.d"\n'
+            "[tool.towncrier]\n"
+            + 'directory = "changelog.d"\n'
         )
         # Each subproject contains the source code...
         Path("foo/foo").mkdir(parents=True)

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1344,3 +1344,39 @@ Deprecations and Removals
 
         self.assertEqual(0, result.exit_code, result.output)
         self.assertEqual(expected_output, result.output)
+
+    @with_isolated_runner
+    def test_projects_share_one_config_with_nondefault_directory(self, runner):
+        """
+        Multiple projects with independent changelogs share one towncrier
+        configuration.
+
+        For this to work:
+        1. We need to leave `config.package` empty.
+        2. We need to pass `--dir` to `create` and `build` explicitly.
+           It must point to the project folder.
+        3. We need to pass `--config` pointing at the global configuration.
+        4. We need to make sure `config.directory` and `config.filename` are resolved
+           relative to what we passed as `--dir`.
+        """
+        # We don't want to specify the package because we have multiple ones.
+        Path("pyproject.toml").write_text(
+            # Important to customize `config.directory` because the default
+            # already supports this scenario.
+            "[tool.towncrier]\n" + 'directory = "changelog.d"\n'
+        )
+        # Each subproject contains the source code...
+        Path("foo/foo").mkdir(parents=True)
+        Path("foo/foo/__init__.py").write_text("")
+        # ... and the changelog machinery.
+        Path("foo/changelog.d").mkdir()
+        Path("foo/changelog.d/123.feature").write_text("Adds levitation")
+        self.assertFalse(Path("foo/NEWS.rst").exists())
+
+        result = runner.invoke(
+            cli,
+            ("--yes", "--config", "pyproject.toml", "--dir", "foo", "--version", "1.0"),
+        )
+
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(Path("foo/NEWS.rst").exists())

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -149,7 +149,7 @@ class TestCli(TestCase):
         Using the `--dir` CLI argument, the NEWS file can
         be generated in a sub-directory from fragments
         that are relatives to that sub-directory.
-        
+
         The path passed to `--dir` becomes the
         working directory.
         """

--- a/src/towncrier/test/test_check.py
+++ b/src/towncrier/test/test_check.py
@@ -301,9 +301,8 @@ class TestChecker(TestCase):
     @with_isolated_runner
     def test_in_different_dir_with_nondefault_newsfragments_directory(self, runner):
         """
-        Config location differs from the base directory for news file and fragments.
-
-        This is useful when multiple projects share one towncrier configuration.
+        It can check the fragments located in a sub-directory
+        that is specified using the `--dir` CLI argument.
         """
         main_branch = "main"
         Path("pyproject.toml").write_text(

--- a/src/towncrier/test/test_create.py
+++ b/src/towncrier/test/test_create.py
@@ -253,9 +253,11 @@ class TestCli(TestCase):
     @with_isolated_runner
     def test_in_different_dir_with_nondefault_newsfragments_directory(self, runner):
         """
-        Config location differs from the base directory for news file and fragments.
-
-        This is useful when multiple projects share one towncrier configuration.
+        When the `--dir` CLI argument is passed,
+        it will create a new file in directory that is
+        created by combining the `--dir` value
+        with the `directory` option from the configuration
+        file.
         """
         Path("pyproject.toml").write_text(
             # Important to customize `config.directory` because the default


### PR DESCRIPTION

# Description
<!-- add a short summary if necessary; mention issue numbers -->

This adds official support for the scenario where one towncrier config is shared between multiple projects with independent news files and fragments.

This is useful in monorepo-style setups.

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [ ] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [ ] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
