### PR TITLE
docs(tutorial): Cleanup duplicate backtick typo

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -130,7 +130,7 @@ You should get an output similar to this::
    Improved Documentation
    ----------------------
 
-   - Can also be ``rst``` as well! (#3456, #7890)
+   - Can also be ``rst`` as well! (#3456, #7890)
 
 
    Deprecations and Removals

--- a/src/towncrier/newsfragments/551.doc
+++ b/src/towncrier/newsfragments/551.doc
@@ -1,0 +1,1 @@
+Cleanup a duplicate backtick in the tutorial.

--- a/src/towncrier/newsfragments/docs-tutorial-backtick.doc.rst
+++ b/src/towncrier/newsfragments/docs-tutorial-backtick.doc.rst
@@ -1,0 +1,2 @@
+Cleanup a duplicate backtick in `an example in the tutorial
+<https://towncrier.readthedocs.io/en/stable/tutorial.html#creating-news-fragments>`_.

--- a/src/towncrier/newsfragments/docs-tutorial-backtick.doc.rst
+++ b/src/towncrier/newsfragments/docs-tutorial-backtick.doc.rst
@@ -1,2 +1,0 @@
-Cleanup a duplicate backtick in `an example in the tutorial
-<https://towncrier.readthedocs.io/en/stable/tutorial.html#creating-news-fragments>`_.


### PR DESCRIPTION
# Description
Cleanup a duplicate backtick in [an example in the tutorial](https://towncrier.readthedocs.io/en/stable/tutorial.html#creating-news-fragments).

# Checklist
* ~~Make sure changes are covered by existing or new tests.~~
* ~~For at least one Python version, make sure local test run is green.~~
* [X] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [X] Ensure `docs/tutorial.rst` is still up-to-date.
* ~~If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.~~
* ~~If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.~~
