### PR TITLE
Make consistent the expectation around non-existent fragments directory

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -24,6 +24,12 @@ The following options can be passed to all of the commands that explained below:
 Build the combined news file from news fragments.
 ``build`` is also assumed if no command is passed.
 
+If there are no news fragments (including an empty fragments directory), a
+notice of "no significant changes" will be added to the news file.
+
+By default, the processed news fragments are removed using ``git``, which will
+also remove the fragments directory if now empty.
+
 .. option:: --draft
 
    Only render news fragments to standard output.
@@ -66,6 +72,8 @@ Create a news fragment in the directory that ``towncrier`` is configured to look
    $ towncrier create 123.bugfix.rst
 
 ``towncrier create`` will enforce that the passed type (e.g. ``bugfix``) is valid.
+
+If the fragments directory does not exist, it will be created.
 
 If the filename exists already, ``towncrier create`` will add (and then increment) a number after the fragment type until it finds a filename that does not exist yet.
 In the above example, it will generate ``123.bugfix.1.rst`` if ``123.bugfix.rst`` already exists.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -24,8 +24,9 @@ The following options can be passed to all of the commands that explained below:
 Build the combined news file from news fragments.
 ``build`` is also assumed if no command is passed.
 
-If there are no news fragments (including an empty fragments directory), a
-notice of "no significant changes" will be added to the news file.
+If there are no news fragments (including an empty fragments directory or a
+non-existent directory), a notice of "no significant changes" will be added to
+the news file.
 
 By default, the processed news fragments are removed using ``git``, which will
 also remove the fragments directory if now empty.

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -6,14 +6,11 @@ from __future__ import annotations
 
 import os
 import textwrap
-import traceback
 
 from collections import defaultdict
 from typing import Any, DefaultDict, Iterable, Iterator, Mapping, Sequence
 
 from jinja2 import Template
-
-from ._settings import ConfigError
 
 
 def strip_if_integer_string(s: str) -> str:
@@ -102,11 +99,8 @@ def find_fragments(
 
         try:
             files = os.listdir(section_dir)
-        except FileNotFoundError as e:
-            message = "Failed to list the news fragment files.\n{}".format(
-                "".join(traceback.format_exception_only(type(e), e)),
-            )
-            raise ConfigError(message)
+        except FileNotFoundError:
+            files = []
 
         file_content = {}
 

--- a/src/towncrier/newsfragments/538.bugfix
+++ b/src/towncrier/newsfragments/538.bugfix
@@ -1,0 +1,1 @@
+``build`` now treats a missing fragments directory the same as an empty one, consistent with other operations.

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -182,8 +182,8 @@ class TestCli(TestCase):
 
         result = runner.invoke(_main, ["--draft", "--date", "01-01-2001"])
 
-        self.assertEqual(1, result.exit_code, result.output)
-        self.assertIn("Failed to list the news fragment files.\n", result.output)
+        self.assertEqual(0, result.exit_code)
+        self.assertIn("No significant changes.\n", result.output)
 
     def test_no_newsfragments_draft(self):
         """


### PR DESCRIPTION
# Description

In the first commit, I update the documentation to reflect the current behavior, highlighting that a missing fragments directory is normal for a "create" operation and caused by the "build" operation.

In the second commit, I expand the documentation to include the case where "build" is invoked and the fragments directory is missing to be consistent with an empty directory or no directory at all. I also draft a likely way to achieve this behavior. Once tests pass, this approach closes #538.

Note that this change aligns the behavior with the [currently prescribed expectation](https://github.com/twisted/towncrier/blob/0b023fa95926470482418d4e11f9ae9f0ada7d56/src/towncrier/test/test_build.py#L178).

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [x] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
