### PR TITLE
Update build-and-inspect-python-package to 1.5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: hynek/build-and-inspect-python-package@6a687a6d3567bc184c1fc694ee7f0f328594ef25
+    - uses: hynek/build-and-inspect-python-package@54d50a852d960c25f25f7f1874d3d969ecbe4eb0
 
     - name: Set up ${{ matrix.python.name }}
       uses: actions/setup-python@v4


### PR DESCRIPTION
1.5 is broken as GitHub Actions switched 3.x to 3.12 by default
