### PR TITLE
#571 Use pre-commit dog food and update release process for pre-commit autoupdate.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
 
     - name: Install pre-commit
       run: |
-        pre-commit
+        pre-commit install
 
     - name: Update pre-commit
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,28 @@ jobs:
         ${{ matrix.task.run }}
       if: ${{ matrix.task.run-if }}
 
+  pre-commit:
+    name: pre-commit
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+
+    - name: Install dependencies
+      run: python -m pip pre-commit
+
+    - name: Check
+      run: |
+        ${{ matrix.task.run }}
+      if: ${{ matrix.task.run-if }}
+
 
   pypi-publish:
     name: Check tag and publish
@@ -292,6 +314,7 @@ jobs:
       - test-windows
       - coverage
       - check
+      - pre-commit
     steps:
       - name: Require all successes
         uses: re-actors/alls-green@3a2de129f0713010a71314c74e33c0e3ef90e696

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,8 +194,9 @@ jobs:
         ${{ matrix.task.run }}
       if: ${{ matrix.task.run-if }}
 
+
   pre-commit:
-    name: pre-commit
+    name: Check pre-commit integration
     runs-on: ubuntu-latest
 
     steps:
@@ -211,10 +212,17 @@ jobs:
     - name: Install dependencies
       run: python -m pip install pre-commit
 
-    - name: Check
+    - name: Install pre-commit
       run: |
-        ${{ matrix.task.run }}
-      if: ${{ matrix.task.run-if }}
+        pre-commit
+
+    - name: Update pre-commit
+      run: |
+        pre-commit autoupdate
+
+    - name: Run pre-commit
+      run: |
+        pre-commit run -a
 
 
   pypi-publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
         python-version: 3.12
 
     - name: Install dependencies
-      run: python -m pip pre-commit
+      run: python -m pip install pre-commit
 
     - name: Check
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 24.4.2
     hooks:
       - id: black
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,8 @@ repos:
       - id: debug-statements
       - id: check-toml
       - id: check-yaml
+
+  - repo: https://github.com/twisted/towncrier
+    rev: 23.11.0
+    hooks:
+      - id: towncrier-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     - id: flake8
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: trunk
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     - id: flake8
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,6 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/twisted/towncrier
-    rev: 23.11.0
+    rev: trunk
     hooks:
       - id: towncrier-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     - id: flake8
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: trunk
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -35,6 +35,6 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/twisted/towncrier
-    rev: trunk
+    rev: 23.11.0
     hooks:
       - id: towncrier-check

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -102,7 +102,14 @@ In ``src/towncrier/_version.py`` the version is set using ``incremental`` such a
 
 Commit and push the changes.
 
-Merge the commit in the main branch.
+Merge the commit in the main branch, **without using squash**.
+
+We tag the release based on a commit from the release branch.
+If we merge with squash,
+the release tag commit will no longer be found in the main branch history.
+With a squash merge, the whole branch history is lost.
+This causes the `pre-commit autoupdate` to fail.
+See `PR590 <https://github.com/twisted/towncrier/pull/590>`_ for more details.
 
 You can announce the release over IRC or Gitter.
 

--- a/docs/pre-commit.rst
+++ b/docs/pre-commit.rst
@@ -16,7 +16,7 @@ Usage with the default configuration
 
     repos:
       - repo: https://github.com/twisted/towncrier
-        rev: 22.13.0  # run 'pre-commit autoupdate' to update
+        rev: 23.11.0  # run 'pre-commit autoupdate' to update
         hooks:
           - id: towncrier-check
 
@@ -30,7 +30,7 @@ News fragments are stored in ``changelog.d/`` in the root of the repository and 
 
     repos:
       - repo: https://github.com/twisted/towncrier
-        rev: 22.13.0  # run 'pre-commit autoupdate' to update
+        rev: 23.11.0  # run 'pre-commit autoupdate' to update
         hooks:
           - id: towncrier-update
             files: $changelog\.d/


### PR DESCRIPTION
# Description
Fixes: #571

Try to reproduce the reported error.

Besides using `pre-commit` as part of our CI

this updates the release process to make it work with `pre-commit auto-update`