### PR TITLE
Unpin hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "hatchling ~= 1.17.1",
+    "hatchling",
     "incremental == 22.10.0",
 ]
 build-backend = "hatchling.build"


### PR DESCRIPTION
It's breaking the build. I don't think such a pin on a package we don't control makes any sense. As we're currently seeing, it can break the build just like an incompatible update.