### PR TITLE
Add explicit encoding to read_text.

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -146,6 +146,8 @@ You should get an output similar to this::
 
 Note: if you configure a Markdown file (for example, ``filename = "CHANGES.md"``) in your configuration file, the titles will be output in Markdown format instead.
 
+Note: news fragments and the news file are encoded and are expected to be encoded as UTF-8.
+
 
 Producing News Files In Production
 ----------------------------------

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -146,7 +146,7 @@ You should get an output similar to this::
 
 Note: if you configure a Markdown file (for example, ``filename = "CHANGES.md"``) in your configuration file, the titles will be output in Markdown format instead.
 
-Note: news fragments and the news file are encoded and are expected to be encoded as UTF-8.
+Note: all files (news fragments, the news file, the configuration file, and templates) are encoded and are expected to be encoded as UTF-8.
 
 
 Producing News Files In Production

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -112,7 +112,7 @@ def find_fragments(
             full_filename = os.path.join(section_dir, basename)
             fragment_filenames.append(full_filename)
             with open(full_filename, "rb") as f:
-                data = f.read().decode("utf8", "replace")
+                data = f.read().decode("utf-8", "replace")
 
             if (ticket, category, counter) in file_content:
                 raise ValueError(

--- a/src/towncrier/_writer.py
+++ b/src/towncrier/_writer.py
@@ -40,7 +40,7 @@ def append_to_newsfile(
     # Leave newlines alone. This probably leads to inconsistent newlines,
     # because we've loaded existing content with universal newlines, but that's
     # the original behavior.
-    with news_file.open("w", encoding="utf8", newline="") as f:
+    with news_file.open("w", encoding="utf-8", newline="") as f:
         if header:
             f.write(header)
         # If there is no previous body that means we're writing a brand new news file.
@@ -66,7 +66,7 @@ def _figure_out_existing_content(
 
     # If we didn't use universal newlines here, we wouldn't find *start_string*
     # which usually contains a `\n`.
-    with news_file.open(encoding="utf8") as f:
+    with news_file.open(encoding="utf-8") as f:
         content = f.read()
 
     t = content.split(start_string, 1)

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -166,7 +166,9 @@ def __main(
     click.echo("Loading template...", err=to_err)
     if isinstance(config.template, tuple):
         template = (
-            resources.files(config.template[0]).joinpath(config.template[1]).read_text()
+            resources.files(config.template[0])
+            .joinpath(config.template[1])
+            .read_text(encoding="utf-8")
         )
     else:
         with open(config.template, encoding="utf-8") as tmpl:

--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -138,7 +138,7 @@ def __main(
             ctx.exit(1)
         content = edited_content
 
-    with open(segment_file, "w") as f:
+    with open(segment_file, "w", encoding="utf-8") as f:
         f.write(content)
 
     click.echo(f"Created news fragment at {segment_file}")

--- a/src/towncrier/newsfragments/561.bugfix.rst
+++ b/src/towncrier/newsfragments/561.bugfix.rst
@@ -1,0 +1,1 @@
+Add explicit encoding to read_text.

--- a/src/towncrier/test/helpers.py
+++ b/src/towncrier/test/helpers.py
@@ -36,7 +36,7 @@ def read_pkg_resource(path: str) -> str:
     """
     Read *path* from the towncrier package.
     """
-    return (resources.files("towncrier") / path).read_text("utf8")
+    return (resources.files("towncrier") / path).read_text("utf-8")
 
 
 def with_isolated_runner(fn: Callable[..., Any]) -> Callable[..., Any]:


### PR DESCRIPTION
Closes #561

# Description
<!-- add a short summary if necessary; mention issue numbers -->

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [x] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
