### PR TITLE
fix: Also render title in markdown template without name

### DIFF
--- a/src/towncrier/newsfragments/587.bugfix
+++ b/src/towncrier/newsfragments/587.bugfix
@@ -1,0 +1,1 @@
+The default Markdown template now renders a title containing the release version and date, even when the `name` configuration is left empty.

--- a/src/towncrier/templates/default.md
+++ b/src/towncrier/templates/default.md
@@ -2,7 +2,7 @@
 {% if versiondata.name %}
 # {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
 {% else %}
-{{ versiondata.version }} ({{ versiondata.date }})
+# {{ versiondata.version }} ({{ versiondata.date }})
 {% endif %}
 {% endif %}
 {% for section, _ in sections.items() %}

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1251,6 +1251,53 @@ class TestCli(TestCase):
     @with_project(
         config="""
         [tool.towncrier]
+        name = ""
+        directory = "changes"
+        filename = "NEWS.md"
+        version = "1.2.3"
+        """
+    )
+    def test_markdown_no_name_title(self, runner):
+        """
+        When configured with an empty `name` option,
+        the default template used for Markdown
+        renders the title of the release note with just
+        the version number and release date.
+        """
+        write("changes/123.feature", "Adds levitation")
+        write(
+            "NEWS.md",
+            contents="""
+                A line
+
+                <!-- towncrier release notes start -->
+            """,
+            dedent=True,
+        )
+
+        result = runner.invoke(_main, ["--date", "01-01-2001"], catch_exceptions=False)
+        self.assertEqual(0, result.exit_code, result.output)
+        output = read("NEWS.md")
+
+        expected_output = dedent(
+            """
+            A line
+
+            <!-- towncrier release notes start -->
+
+            # 1.2.3 (01-01-2001)
+
+            ### Features
+
+            - Adds levitation (#123)
+            """
+        )
+
+        self.assertEqual(expected_output, output)
+
+    @with_project(
+        config="""
+        [tool.towncrier]
         title_format = "{version} - {project_date}"
         template = "template.rst"
 


### PR DESCRIPTION
# Description
Previously, if there was no project name defined, the default markdown template wouldn't render the title properly due to a missing `#`. 

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
