### PR TITLE
Fix incorrect handling of orphan fragment names consists of only digits

### DIFF
--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -37,7 +37,8 @@ def parse_newfragment_basename(
             # something-cool.feature.ext for projects that don't use ticket
             # numbers in news fragment names.
             ticket = ".".join(parts[0:i]).strip()
-            # If the ticket is an integer, remove any leading zeros.
+            # If the ticket is an integer, remove any leading zeros (to resolve
+            # issue #126).
             if ticket.isdigit():
                 ticket = str(int(ticket))
             counter = 0

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -13,15 +13,6 @@ from typing import Any, DefaultDict, Iterable, Iterator, Mapping, Sequence
 from jinja2 import Template
 
 
-def strip_if_integer_string(s: str) -> str:
-    try:
-        i = int(s)
-    except ValueError:
-        return s
-
-    return str(i)
-
-
 # Returns ticket, category and counter or (None, None, None) if the basename
 # could not be parsed or doesn't contain a valid category.
 def parse_newfragment_basename(
@@ -45,7 +36,10 @@ def parse_newfragment_basename(
             # NOTE: This allows news fragment names like fix-1.2.3.feature or
             # something-cool.feature.ext for projects that don't use ticket
             # numbers in news fragment names.
-            ticket = strip_if_integer_string(".".join(parts[0:i]))
+            ticket = ".".join(parts[0:i]).strip()
+            # If the ticket is an integer, remove any leading zeros.
+            if ticket.isdigit():
+                ticket = str(int(ticket))
             counter = 0
             # Use the following part as the counter if it exists and is a valid
             # digit.

--- a/src/towncrier/newsfragments/588.bugfix
+++ b/src/towncrier/newsfragments/588.bugfix
@@ -1,1 +1,1 @@
-Fix orphans consisting of only digits (e.g. '+12345678.feature') losing their orphan status.
+Orphan news fragments, fragments not associated with an issue, consisting of only digits (e.g. '+12345678.feature') now retain their leading marker character.

--- a/src/towncrier/newsfragments/588.bugfix
+++ b/src/towncrier/newsfragments/588.bugfix
@@ -1,0 +1,1 @@
+Fix orphans consisting of only digits (e.g. '+12345678.feature') losing their orphan status.

--- a/src/towncrier/test/test_builder.py
+++ b/src/towncrier/test/test_builder.py
@@ -125,3 +125,10 @@ class TestParseNewsfragmentBasename(TestCase):
             parse_newfragment_basename("+orphan_12.3.feature", ["feature"]),
             ("+orphan_12.3", "feature", 0),
         )
+
+    def test_orphan_all_digits(self):
+        """Orphaned snippets can consist of only digits."""
+        self.assertEqual(
+            parse_newfragment_basename("+123.feature", ["feature"]),
+            ("+123", "feature", 0),
+        )


### PR DESCRIPTION
Fixes #584

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
