### PR TITLE
Add docs for CLI orphan fragments

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -79,7 +79,8 @@ If the fragments directory does not exist, it will be created.
 If the filename exists already, ``towncrier create`` will add (and then increment) a number after the fragment type until it finds a filename that does not exist yet.
 In the above example, it will generate ``123.bugfix.1.rst`` if ``123.bugfix.rst`` already exists.
 
-To create a news fragment not tied to a specific issue, start the fragment name with a ``+``. If that is the entire fragment name, a random hash will be added for you::
+To create a news fragment not tied to a specific issue (which towncrier calls an "orphan fragment"), start the fragment name with a ``+``.
+If that is the entire fragment name, a random hash will be added for you::
 
    $ towncrier create +.feature.rst
    $ ls newsfragments/

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -79,6 +79,12 @@ If the fragments directory does not exist, it will be created.
 If the filename exists already, ``towncrier create`` will add (and then increment) a number after the fragment type until it finds a filename that does not exist yet.
 In the above example, it will generate ``123.bugfix.1.rst`` if ``123.bugfix.rst`` already exists.
 
+To create a news fragment not tied to a specific issue, start the fragment name with a ``+``. If that is the entire fragment name, a random hash will be added for you::
+
+   $ towncrier create +.feature.rst
+   $ ls newsfragments/
+   +fcc4dc7b.feature.rst
+
 .. option:: --content, -c CONTENT
 
    A string to use for content.

--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -64,6 +64,9 @@ def _main(
     * .doc - a documentation improvement,
     * .removal - a deprecation or removal of public API,
     * .misc - a ticket has been closed, but it is not of interest to users.
+
+    If the FILENAME base is just '+' (to create a fragment not tied to an
+    issue), it will be appended with a random hex string.
     """
     __main(ctx, directory, config, filename, edit, content)
 

--- a/src/towncrier/newsfragments/589.doc
+++ b/src/towncrier/newsfragments/589.doc
@@ -1,0 +1,1 @@
+Add docs to explain how ``towncrier create +.feature.rst`` (orphan fragments) works.


### PR DESCRIPTION
`towncrier create +.feature.rst` wasn't documented.