### PR TITLE
Add --bleeding-edge into pre-commit autoupdate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
 
     - name: Update pre-commit
       run: |
-        pre-commit autoupdate
+        pre-commit autoupdate --bleeding-edge
 
     - name: Run pre-commit
       run: |


### PR DESCRIPTION
# Description

Resolves #571 and #572

before:
![image](https://github.com/twisted/towncrier/assets/23168063/38883028-b6f2-42fa-aee5-43e638fc694c)

after:
![image](https://github.com/twisted/towncrier/assets/23168063/18289711-fab8-4fba-9796-fb0520ff0c12)


# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [ ] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [ ] Ensure `docs/tutorial.rst` is still up-to-date.
* [ ] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [ ] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
