### PR TITLE
Prefer pathlib for read/write operations

### DIFF
--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -8,6 +8,7 @@ import os
 import textwrap
 
 from collections import defaultdict
+from pathlib import Path
 from typing import Any, DefaultDict, Iterable, Iterator, Mapping, Sequence
 
 from jinja2 import Template
@@ -111,8 +112,7 @@ def find_fragments(
 
             full_filename = os.path.join(section_dir, basename)
             fragment_filenames.append(full_filename)
-            with open(full_filename, "rb") as f:
-                data = f.read().decode("utf-8", "replace")
+            data = Path(full_filename).read_text(encoding="utf-8", errors="replace")
 
             if (ticket, category, counter) in file_content:
                 raise ValueError(

--- a/src/towncrier/_writer.py
+++ b/src/towncrier/_writer.py
@@ -17,7 +17,7 @@ from typing import Any
 if sys.version_info < (3, 10):
 
     def _newline_write_text(path: Path, content: str, **kwargs: Any) -> None:
-        with path.open("w", **kwargs) as strm:
+        with path.open("w", **kwargs) as strm:  # pragma: no cover
             strm.write(content)
 
 else:

--- a/src/towncrier/_writer.py
+++ b/src/towncrier/_writer.py
@@ -65,8 +65,6 @@ def _figure_out_existing_content(
         # Non-existent files have no existing content.
         return "", ""
 
-    # If we didn't use universal newlines here, we wouldn't find *start_string*
-    # which usually contains a `\n`.
     content = Path(news_file).read_text(encoding="utf-8")
 
     t = content.split(start_string, 1)

--- a/src/towncrier/_writer.py
+++ b/src/towncrier/_writer.py
@@ -37,15 +37,16 @@ def append_to_newsfile(
     if top_line and top_line in prev_body:
         raise ValueError("It seems you've already produced newsfiles for this version?")
 
-    # Leave newlines alone. This probably leads to inconsistent newlines,
-    # because we've loaded existing content with universal newlines, but that's
-    # the original behavior.
-    with news_file.open("w", encoding="utf-8", newline="") as f:
-        if header:
-            f.write(header)
+    news_file.write_text(
         # If there is no previous body that means we're writing a brand new news file.
         # We don't want extra whitespace at the end of this new file.
-        f.write(content + prev_body if prev_body else content.rstrip() + "\n")
+        header + (content + prev_body if prev_body else content.rstrip() + "\n"),
+        encoding="utf-8",
+        # Leave newlines alone. This probably leads to inconsistent newlines,
+        # because we've loaded existing content with universal newlines, but that's
+        # the original behavior.
+        newline="",
+    )
 
 
 def _figure_out_existing_content(
@@ -66,8 +67,7 @@ def _figure_out_existing_content(
 
     # If we didn't use universal newlines here, we wouldn't find *start_string*
     # which usually contains a `\n`.
-    with news_file.open(encoding="utf-8") as f:
-        content = f.read()
+    content = Path(news_file).read_text(encoding="utf-8")
 
     t = content.split(start_string, 1)
     if len(t) == 2:

--- a/src/towncrier/_writer.py
+++ b/src/towncrier/_writer.py
@@ -8,7 +8,22 @@ affecting existing content.
 
 from __future__ import annotations
 
+import sys
+
 from pathlib import Path
+from typing import Any
+
+
+if sys.version_info < (3, 10):
+
+    def _newline_write_text(path: Path, content: str, **kwargs: Any) -> None:
+        with path.open("w", **kwargs) as strm:
+            strm.write(content)
+
+else:
+
+    def _newline_write_text(path: Path, content: str, **kwargs: Any) -> None:
+        path.write_text(content, **kwargs)
 
 
 def append_to_newsfile(
@@ -37,7 +52,8 @@ def append_to_newsfile(
     if top_line and top_line in prev_body:
         raise ValueError("It seems you've already produced newsfiles for this version?")
 
-    news_file.write_text(
+    _newline_write_text(
+        news_file,
         # If there is no previous body that means we're writing a brand new news file.
         # We don't want extra whitespace at the end of this new file.
         header + (content + prev_body if prev_body else content.rstrip() + "\n"),

--- a/src/towncrier/_writer.py
+++ b/src/towncrier/_writer.py
@@ -15,7 +15,7 @@ from typing import Any
 
 
 if sys.version_info < (3, 10):
-
+    # Compatibility shim for newline parameter to write_text, added in 3.10
     def _newline_write_text(path: Path, content: str, **kwargs: Any) -> None:
         with path.open("w", **kwargs) as strm:  # pragma: no branch
             strm.write(content)

--- a/src/towncrier/_writer.py
+++ b/src/towncrier/_writer.py
@@ -17,7 +17,7 @@ from typing import Any
 if sys.version_info < (3, 10):
 
     def _newline_write_text(path: Path, content: str, **kwargs: Any) -> None:
-        with path.open("w", **kwargs) as strm:  # pragma: no cover
+        with path.open("w", **kwargs) as strm:  # pragma: no branch
             strm.write(content)
 
 else:

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -5,13 +5,13 @@
 Build a combined news file from news fragments.
 """
 
-
 from __future__ import annotations
 
 import os
 import sys
 
 from datetime import date
+from pathlib import Path
 
 import click
 
@@ -171,8 +171,7 @@ def __main(
             .read_text(encoding="utf-8")
         )
     else:
-        with open(config.template, encoding="utf-8") as tmpl:
-            template = tmpl.read()
+        template = Path(config.template).read_text(encoding="utf-8")
 
     click.echo("Finding news fragments...", err=to_err)
 

--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import os
 
+from pathlib import Path
+
 import click
 
 from ._settings import config_option_help, load_config_from_options
@@ -170,10 +172,10 @@ def __main(
             click.echo("Aborted creating news fragment due to empty message.")
             ctx.exit(1)
 
-    with open(segment_file, "w", encoding="utf-8") as f:
-        f.write(content)
-        if config.create_eof_newline and content and not content.endswith("\n"):
-            f.write("\n")
+    add_newline = bool(
+        config.create_eof_newline and content and not content.endswith("\n")
+    )
+    Path(segment_file).write_text(content + "\n" * add_newline, encoding="utf-8")
 
     click.echo(f"Created news fragment at {segment_file}")
 

--- a/src/towncrier/newsfragments/591.misc.rst
+++ b/src/towncrier/newsfragments/591.misc.rst
@@ -1,0 +1,1 @@
+Leveraged pathlib in most file operations.


### PR DESCRIPTION
- **Rely on pathlib when reading and writing simple text.**
- **Universal newlines is the default, so remove the comment.**

# Description
While working on #577, I noticed it might be nice to leverage pathlib for reading and writing files. This approach avoids adding nesting and with blocks by utilizing `read_text` and `write_text`.

This PR depends on #577 and should be rebased after merging that one.

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [x] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
