### PR TITLE
Remove unused `wheel` build dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip
         python -m pip install pep517
 
     - name: Display structure of files to be pushed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "hatchling",
-    "wheel",
 ]
 build-backend = "hatchling.build"
 

--- a/src/towncrier/newsfragments/629.misc
+++ b/src/towncrier/newsfragments/629.misc
@@ -1,0 +1,1 @@
+Removed build-time dependency on `wheel`.


### PR DESCRIPTION
# Description
Remove the `wheel` dependency as it is not used anywhere.  Hatchling does not use `wheel` (and setuptools either bundled it or pulled it in automatically).

# Checklist
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure local test run is green.
* [x] Create a file in `src/towncrier/newsfragments/`. Describe your
  change and include important information. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [x] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
