### PR TITLE
Stop using deprecated packages in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
 jobs:
   build:
     name: ${{ matrix.task.name}} - ${{ matrix.os.name }} ${{ matrix.python.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,32 @@ jobs:
     - name: Publish to PyPI - on tag
       uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598
 
+  fake-pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Download package files
+      uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist/
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.12
+
+    - name: Display structure of files to be pushed
+      run: ls --recursive dist/
+
+    - name: Ensure tag and package versions match.
+      run: |
+        python -Im pip install dist/*.whl
+        python -I admin/check_tag_version_match.py "${{ github.ref }}"
+
 
   coverage:
     name: Combine & check coverage.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,32 +266,6 @@ jobs:
     - name: Publish to PyPI - on tag
       uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598
 
-  fake-pypi-publish:
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Download package files
-      uses: actions/download-artifact@v3
-      with:
-        name: dist
-        path: dist/
-
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.12
-
-    - name: Display structure of files to be pushed
-      run: ls --recursive dist/
-
-    - name: Ensure tag and package versions match.
-      run: |
-        python -Im pip install dist/*.whl
-        python -I admin/check_tag_version_match.py "${{ github.ref }}"
-
 
   coverage:
     name: Combine & check coverage.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,18 +250,15 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pep517
+        python-version: 3.12
 
     - name: Display structure of files to be pushed
       run: ls --recursive dist/
 
-    - name: Check matched tag version and branch version - on tag
-      run: python admin/check_tag_version_match.py "${{ github.ref }}"
+    - name: Ensure tag and package versions match.
+      run: |
+        python -Im pip install dist/*.whl
+        python -I admin/check_tag_version_match.py "${{ github.ref }}"
 
     - name: Publish to PyPI - on tag
       uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598

--- a/admin/check_tag_version_match.py
+++ b/admin/check_tag_version_match.py
@@ -19,7 +19,8 @@ if len(sys.argv) < 2:
     print("No tag check requested.")
     sys.exit(0)
 
-branch_version = metadata.version("towncrier")
+pkg_version = metadata.version("towncrier")
+print(f"Package version is {pkg_version}.")
 run_version = sys.argv[1]
 
 if not run_version.startswith(TAG_PREFIX):
@@ -28,9 +29,9 @@ if not run_version.startswith(TAG_PREFIX):
 
 run_version = run_version[len(TAG_PREFIX) :]  # noqa: E203
 
-if run_version != branch_version:
-    print(f"Package is at '{branch_version}' while tag is '{run_version}'")
+if run_version != pkg_version:
+    print(f"Package is at '{pkg_version}' while tag is '{run_version}'")
     exit(1)
 
-print(f"All good. Package and tag versions match for '{branch_version}'.")
+print(f"All good. Package and tag versions match for '{pkg_version}'.")
 sys.exit(0)

--- a/admin/check_tag_version_match.py
+++ b/admin/check_tag_version_match.py
@@ -1,15 +1,16 @@
 #
 # Used during the release process to make sure that we release based on a
-# tag that has the same version as the current twisted.__version.
+# tag that has the same version as the current packaging metadata.
 #
 # Designed to be conditionally called inside GitHub Actions release job.
 # Tags should use PEP440 version scheme.
 #
-# To be called as: admin/check_tag_version_match.py refs/tags/twisted-20.3.0
+# To be called as: admin/check_tag_version_match.py refs/tags/20.3.0
 #
+
 import sys
 
-import pep517.meta
+from importlib import metadata
 
 
 TAG_PREFIX = "refs/tags/"
@@ -18,7 +19,7 @@ if len(sys.argv) < 2:
     print("No tag check requested.")
     sys.exit(0)
 
-branch_version = pep517.meta.load(".").version
+branch_version = metadata.version("towncrier")
 run_version = sys.argv[1]
 
 if not run_version.startswith(TAG_PREFIX):
@@ -28,8 +29,8 @@ if not run_version.startswith(TAG_PREFIX):
 run_version = run_version[len(TAG_PREFIX) :]  # noqa: E203
 
 if run_version != branch_version:
-    print(f"Branch is at '{branch_version}' while tag is '{run_version}'")
+    print(f"Package is at '{branch_version}' while tag is '{run_version}'")
     exit(1)
 
-print(f"All good. Branch and tag versions match for '{branch_version}'.")
+print(f"All good. Package and tag versions match for '{branch_version}'.")
 sys.exit(0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,5 @@
 [build-system]
-requires = [
-    "hatchling",
-]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 


### PR DESCRIPTION
pep517 has been deprecated for a long time and we don't need it anymore, courtesy of `importlib.metadata`.

I appreciate that it's a bit icky since we cannot test it before actually releasing, and I really don't want to slow down a future release.