### PR TITLE
Add support for wildcards in ignore

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -132,6 +132,7 @@ Top level keys
 
 ``ignore``
     A case-insensitive list of filenames in the news fragments directory to ignore.
+    Wildcard matching is supported via the `fnmatch <https://docs.python.org/3/library/fnmatch.html#fnmatch.fnmatch>`_ function.
 
     ``towncrier check`` will fail if there are any news fragment files that have invalid filenames, except for those in the list. ``towncrier build`` will likewise fail, but only if this list has been configured (set to an empty list if there are no files to ignore).
 

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -9,6 +9,7 @@ import re
 import textwrap
 
 from collections import defaultdict
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, DefaultDict, Iterable, Iterator, Mapping, NamedTuple, Sequence
 
@@ -142,7 +143,12 @@ def find_fragments(
         file_content = {}
 
         for basename in files:
-            if basename.lower() in ignored_files:
+            if any(
+                [
+                    fnmatch(basename.lower(), ignore_pattern)
+                    for ignore_pattern in ignored_files
+                ]
+            ):
                 continue
 
             issue, category, counter = parse_newfragment_basename(

--- a/src/towncrier/newsfragments/644.feature.rst
+++ b/src/towncrier/newsfragments/644.feature.rst
@@ -1,0 +1,1 @@
+Config `ignore` option now supports wildcard matching via `fnmatch <https://docs.python.org/3/library/fnmatch.html#fnmatch.fnmatch>`_.

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1588,7 +1588,8 @@ class TestCli(TestCase):
         config="""
         [tool.towncrier]
         package = "foo"
-        ignore = ["template.jinja", "CAPYBARAS.md"]
+        ignore = ["template.jinja", "CAPYBARAS.md", \
+        "star_wildcard*", "question_wildcard_?", "seq_wildcard_[ab]"]
         """
     )
     def test_ignored_files(self, runner):
@@ -1603,6 +1604,12 @@ class TestCli(TestCase):
             f.write("This markdown file has been manually ignored")
         with open("foo/newsfragments/.gitignore", "w") as f:
             f.write("gitignore is automatically ignored")
+        with open("foo/newsfragments/star_wildcard_bar", "w") as f:
+            f.write("Manually ignored with * wildcard")
+        with open("foo/newsfragments/question_wildcard_1", "w") as f:
+            f.write("Manually ignored with ? wildcard")
+        with open("foo/newsfragments/seq_wildcard_a", "w") as f:
+            f.write("Manually ignored with [] wildcard")
 
         result = runner.invoke(_main, ["--draft"])
         self.assertEqual(0, result.exit_code, result.output)

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1588,13 +1588,13 @@ class TestCli(TestCase):
         config="""
         [tool.towncrier]
         package = "foo"
-        ignore = ["template.jinja", "CAPYBARAS.md", \
-        "star_wildcard*", "question_wildcard_?", "seq_wildcard_[ab]"]
+        ignore = ["template.jinja", "CAPYBARAS.md", "seq_wildcard_[ab]"]
         """
     )
     def test_ignored_files(self, runner):
         """
         When `ignore` is set in config, files with those names are ignored.
+        Configuration supports wildcard matching with `fnmatch`.
         """
         with open("foo/newsfragments/123.feature", "w") as f:
             f.write("This has valid filename (control case)")
@@ -1604,10 +1604,6 @@ class TestCli(TestCase):
             f.write("This markdown file has been manually ignored")
         with open("foo/newsfragments/.gitignore", "w") as f:
             f.write("gitignore is automatically ignored")
-        with open("foo/newsfragments/star_wildcard_bar", "w") as f:
-            f.write("Manually ignored with * wildcard")
-        with open("foo/newsfragments/question_wildcard_1", "w") as f:
-            f.write("Manually ignored with ? wildcard")
         with open("foo/newsfragments/seq_wildcard_a", "w") as f:
             f.write("Manually ignored with [] wildcard")
 

--- a/src/towncrier/test/test_check.py
+++ b/src/towncrier/test/test_check.py
@@ -476,7 +476,11 @@ class TestChecker(TestCase):
         """
         When `ignore` is set in config, files with those names are ignored.
         """
-        create_project("pyproject.toml", extra_config='ignore = ["template.jinja"]')
+        create_project(
+            "pyproject.toml",
+            extra_config='ignore = ["template.jinja", "star_wildcard*", "question_wildcard_?", '
+            '"seq_wildcard_[ab]"]',
+        )
 
         write(
             "foo/newsfragments/124.feature",
@@ -484,6 +488,16 @@ class TestChecker(TestCase):
         )
         write("foo/newsfragments/template.jinja", "This is manually ignored")
         write("foo/newsfragments/.gitignore", "gitignore is automatically ignored")
+        write("foo/newsfragments/star_wildcard_foo", "Manually ignored with * wildcard")
+        write("foo/newsfragments/STAR_WILDCARD_bar", "Manually ignored with * wildcard")
+        write(
+            "foo/newsfragments/question_wildcard_1", "Manually ignored with ? wildcard"
+        )
+        write(
+            "foo/newsfragments/QUESTION_WILDCARD_1", "Manually ignored with ? wildcard"
+        )
+        write("foo/newsfragments/seq_wildcard_a", "Manually ignored with [] wildcard")
+        write("foo/newsfragments/SEQ_WILDCARD_b", "Manually ignored with [] wildcard")
         commit("add stuff")
 
         result = runner.invoke(towncrier_check, ["--compare-with", "main"])

--- a/src/towncrier/test/test_check.py
+++ b/src/towncrier/test/test_check.py
@@ -475,11 +475,11 @@ class TestChecker(TestCase):
     def test_ignored_files(self, runner):
         """
         When `ignore` is set in config, files with those names are ignored.
+        Configuration supports wildcard matching with `fnmatch`.
         """
         create_project(
             "pyproject.toml",
-            extra_config='ignore = ["template.jinja", "star_wildcard*", "question_wildcard_?", '
-            '"seq_wildcard_[ab]"]',
+            extra_config='ignore = ["template.jinja", "star_wildcard*"]',
         )
 
         write(
@@ -489,15 +489,6 @@ class TestChecker(TestCase):
         write("foo/newsfragments/template.jinja", "This is manually ignored")
         write("foo/newsfragments/.gitignore", "gitignore is automatically ignored")
         write("foo/newsfragments/star_wildcard_foo", "Manually ignored with * wildcard")
-        write("foo/newsfragments/STAR_WILDCARD_bar", "Manually ignored with * wildcard")
-        write(
-            "foo/newsfragments/question_wildcard_1", "Manually ignored with ? wildcard"
-        )
-        write(
-            "foo/newsfragments/QUESTION_WILDCARD_1", "Manually ignored with ? wildcard"
-        )
-        write("foo/newsfragments/seq_wildcard_a", "Manually ignored with [] wildcard")
-        write("foo/newsfragments/SEQ_WILDCARD_b", "Manually ignored with [] wildcard")
         commit("add stuff")
 
         result = runner.invoke(towncrier_check, ["--compare-with", "main"])


### PR DESCRIPTION
# Description

Fixes #642 

The `ignore` config option now supports wildcard matching. Any wildcards understood by [fnmatch](https://docs.python.org/3/library/fnmatch.html#fnmatch.fnmatch) are supported.

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure test pass on your local environment.
* [x] Create a file in `src/towncrier/newsfragments/`. Briefly describe your
  changes, with information useful to end users. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [x] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
