### PR TITLE
add utility function to calculate underline size for category names

### DIFF
--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -20,7 +20,7 @@ from jinja2 import Template
 from towncrier._settings.load import Config
 
 
-UnderlineLengthType = float | str | int | dict[str, Any] | list[Any]
+UnderlineLengthType = float | str | int | dict[Any, Any] | list[Any]
 
 
 # Returns issue, category and counter or (None, None, None) if the basename
@@ -207,7 +207,7 @@ def find_fragments(
     return content, fragment_files
 
 
-def get_dict_length(obj: dict[str, Any]) -> int:
+def get_dict_length(obj: dict[UnderlineLengthType, UnderlineLengthType]) -> int:
     """
     Gets the sum of the underline lengths for all keys and values in a dictionary.
     """
@@ -217,7 +217,7 @@ def get_dict_length(obj: dict[str, Any]) -> int:
     )
 
 
-def get_list_length(obj: list[Any]) -> int:
+def get_list_length(obj: list[UnderlineLengthType]) -> int:
     """
     Gets the sum of the underline lengths for all items in a list.
     """

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -263,7 +263,6 @@ def split_fragments(
                 # it's recorded.
                 content = ""
 
-            # Calculate the underline size for the name of the category.
             definitions[category]["underline_size"] = get_underline_size(
                 definitions[category]["name"]
             )
@@ -433,6 +432,7 @@ def render_fragments(
         top_underline=top_underline,
         get_indent=get_indent,  # simplify indentation in the jinja template.
         issues_by_category=issues_by_category,
+        versiondata_name_underline_size=get_underline_size(versiondata.get("name", "")),
     )
 
     for line in res.split("\n"):

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -204,20 +204,20 @@ def find_fragments(
     return content, fragment_files
 
 
-def get_underline_size(text: str) -> int:
+def get_underline_length(text: str) -> int:
     """
-    Given `text` determine the underline size needed for the reStructuredText output.
+    Given `text` determine the underline length needed for the reStructuredText output.
 
     Particularly helps determine if an extra underline is needed for wide characters like emojis.
     """
-    underline_size: int = 0
+    underline_length: int = 0
     for char in text:
         if unicodedata.east_asian_width(char) in ("W", "F"):
-            underline_size += 2
+            underline_length += 2
         else:
-            underline_size += 1
+            underline_length += 1
 
-    return underline_size
+    return underline_length
 
 
 def indent(text: str, prefix: str) -> str:
@@ -263,7 +263,7 @@ def split_fragments(
                 # it's recorded.
                 content = ""
 
-            definitions[category]["underline_size"] = get_underline_size(
+            definitions[category]["underline_length"] = get_underline_length(
                 definitions[category]["name"]
             )
 
@@ -432,7 +432,9 @@ def render_fragments(
         top_underline=top_underline,
         get_indent=get_indent,  # simplify indentation in the jinja template.
         issues_by_category=issues_by_category,
-        versiondata_name_underline_size=get_underline_size(versiondata.get("name", "")),
+        versiondata_name_underline_length=get_underline_length(
+            versiondata.get("name", "")
+        ),
     )
 
     for line in res.split("\n"):

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -20,6 +20,9 @@ from jinja2 import Template
 from towncrier._settings.load import Config
 
 
+UnderlineLengthType = float | str | int | dict[str, Any] | list[Any]
+
+
 # Returns issue, category and counter or (None, None, None) if the basename
 # could not be parsed or doesn't contain a valid category.
 def parse_newfragment_basename(
@@ -204,7 +207,7 @@ def find_fragments(
     return content, fragment_files
 
 
-def get_dict_length(obj: dict) -> int:
+def get_dict_length(obj: dict[str, Any]) -> int:
     """
     Gets the sum of the underline lengths for all keys and values in a dictionary.
     """
@@ -214,7 +217,7 @@ def get_dict_length(obj: dict) -> int:
     )
 
 
-def get_list_length(obj: list) -> int:
+def get_list_length(obj: list[Any]) -> int:
     """
     Gets the sum of the underline lengths for all items in a list.
     """
@@ -230,7 +233,7 @@ def get_string_length(text: str) -> int:
     )
 
 
-def get_underline_length(obj: str | dict | list) -> int:
+def get_underline_length(obj: UnderlineLengthType) -> int:
     """
     Given `obj` determine the underline length needed for the reStructuredText output.
 
@@ -242,7 +245,9 @@ def get_underline_length(obj: str | dict | list) -> int:
         return get_list_length(obj)
     elif isinstance(obj, str):
         return get_string_length(obj)
-    raise ValueError("Object must be a string, list, or dictionary.")
+    elif isinstance(obj, int) or isinstance(obj, float):
+        return len(str(obj))
+    raise TypeError("Object must be a string, int, float, list, or dictionary.")
 
 
 def indent(text: str, prefix: str) -> str:

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -12,7 +12,16 @@ import unicodedata
 from collections import defaultdict
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Any, DefaultDict, Iterable, Iterator, Mapping, NamedTuple, Sequence
+from typing import (
+    Any,
+    DefaultDict,
+    Iterable,
+    Iterator,
+    Mapping,
+    NamedTuple,
+    Sequence,
+    TypeAlias,
+)
 
 from click import ClickException
 from jinja2 import Template
@@ -20,7 +29,7 @@ from jinja2 import Template
 from towncrier._settings.load import Config
 
 
-UnderlineLengthType = float | str | int | dict[Any, Any] | list[Any]
+UnderlineLengthType: TypeAlias = float | str | int | dict[Any, Any] | list[Any]
 
 
 # Returns issue, category and counter or (None, None, None) if the basename

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 import re
 import textwrap
+import unicodedata
 
 from collections import defaultdict
 from fnmatch import fnmatch
@@ -203,6 +204,22 @@ def find_fragments(
     return content, fragment_files
 
 
+def get_underline_size(text: str) -> int:
+    """
+    Given `text` determine the underline size needed for the reStructuredText output.
+
+    Particularly helps determine if an extra underline is needed for wide characters like emojis.
+    """
+    underline_size: int = 0
+    for char in text:
+        if unicodedata.east_asian_width(char) in ("W", "F"):
+            underline_size += 2
+        else:
+            underline_size += 1
+
+    return underline_size
+
+
 def indent(text: str, prefix: str) -> str:
     """
     Adds `prefix` to the beginning of non-empty lines in `text`.
@@ -245,6 +262,11 @@ def split_fragments(
                 # the content. If there isn't an issue, still add the content so that
                 # it's recorded.
                 content = ""
+
+            # Calculate the underline size for the name of the category.
+            definitions[category]["underline_size"] = get_underline_size(
+                definitions[category]["name"]
+            )
 
             texts = section.setdefault(category, {})
 

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -21,7 +21,7 @@ from towncrier import _git
 
 from ._builder import (
     find_fragments,
-    get_underline_size,
+    get_underline_length,
     render_fragments,
     split_fragments,
 )
@@ -239,7 +239,7 @@ def __main(
         if is_markdown:
             parts = [top_line]
         else:
-            parts = [top_line, config.underlines[0] * get_underline_size(top_line)]
+            parts = [top_line, config.underlines[0] * get_underline_length(top_line)]
         parts.append(rendered)
         content = "\n".join(parts)
     else:

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -19,7 +19,12 @@ from click import Context, Option, UsageError
 
 from towncrier import _git
 
-from ._builder import find_fragments, render_fragments, split_fragments
+from ._builder import (
+    find_fragments,
+    get_underline_size,
+    render_fragments,
+    split_fragments,
+)
 from ._project import get_project_name, get_version
 from ._settings import ConfigError, config_option_help, load_config_from_options
 from ._writer import append_to_newsfile
@@ -234,7 +239,7 @@ def __main(
         if is_markdown:
             parts = [top_line]
         else:
-            parts = [top_line, config.underlines[0] * len(top_line)]
+            parts = [top_line, config.underlines[0] * get_underline_size(top_line)]
         parts.append(rendered)
         content = "\n".join(parts)
     else:

--- a/src/towncrier/newsfragments/626.bugfix.rst
+++ b/src/towncrier/newsfragments/626.bugfix.rst
@@ -1,1 +1,2 @@
-Fixed section names not having enough underline characters for emojis.
+For reStructuredText format, you can now use emojis in category names.
+In previous versions, the generated underline was not matching the title width.

--- a/src/towncrier/newsfragments/626.bugfix.rst
+++ b/src/towncrier/newsfragments/626.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed section names not having enough underline characters for emojis.

--- a/src/towncrier/templates/default.rst
+++ b/src/towncrier/templates/default.rst
@@ -1,29 +1,29 @@
 {% if render_title %}
 {% if versiondata.name %}
 {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.version + versiondata.date)|length + 4 + versiondata_name_underline_length)}}
+{{ top_underline * (get_underline_length(versiondata.name + versiondata.version + versiondata.date) + 4)}}
 {% else %}
 {{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}
+{{ top_underline * (get_underline_length(versiondata.version + versiondata.date) + 3)}}
 {% endif %}
 {% endif %}
 {% for section, _ in sections.items() %}
 {% set underline = underlines[0] %}{% if section %}{{section}}
-{{ underline * section|length }}{% set underline = underlines[1] %}
+{{ underline * get_underline_length(section) }}{% set underline = underlines[1] %}
 
 {% endif %}
 
 {% if sections[section] %}
 {% for category, val in definitions.items() if category in sections[section]%}
 {{ definitions[category]['name'] }}
-{{ underline * definitions[category]['underline_length'] }}
+{{ underline * get_underline_length(definitions[category]['name']) }}
 
 {% for text, values in sections[section][category].items() %}
 - {% if text %}{{ text }}{% if values %} ({{ values|join(', ') }}){% endif %}{% else %}{{ values|join(', ') }}{% endif  %}
 
 {% endfor %}
 
-{% if sections[section][category]|length == 0 %}
+{% if get_underline_length(sections[section][category]) == 0 %}
 No significant changes.
 
 {% else %}

--- a/src/towncrier/templates/default.rst
+++ b/src/towncrier/templates/default.rst
@@ -16,7 +16,7 @@
 {% if sections[section] %}
 {% for category, val in definitions.items() if category in sections[section]%}
 {{ definitions[category]['name'] }}
-{{ underline * definitions[category]['name']|length }}
+{{ underline * definitions[category]['underline_size'] }}
 
 {% for text, values in sections[section][category].items() %}
 - {% if text %}{{ text }}{% if values %} ({{ values|join(', ') }}){% endif %}{% else %}{{ values|join(', ') }}{% endif  %}

--- a/src/towncrier/templates/default.rst
+++ b/src/towncrier/templates/default.rst
@@ -1,7 +1,7 @@
 {% if render_title %}
 {% if versiondata.name %}
 {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.name + versiondata.version + versiondata.date)|length + 4)}}
+{{ top_underline * ((versiondata.version + versiondata.date)|length + 4 + versiondata_name_underline_size)}}
 {% else %}
 {{ versiondata.version }} ({{ versiondata.date }})
 {{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}

--- a/src/towncrier/templates/default.rst
+++ b/src/towncrier/templates/default.rst
@@ -1,7 +1,7 @@
 {% if render_title %}
 {% if versiondata.name %}
 {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.version + versiondata.date)|length + 4 + versiondata_name_underline_size)}}
+{{ top_underline * ((versiondata.version + versiondata.date)|length + 4 + versiondata_name_underline_length)}}
 {% else %}
 {{ versiondata.version }} ({{ versiondata.date }})
 {{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}
@@ -16,7 +16,7 @@
 {% if sections[section] %}
 {% for category, val in definitions.items() if category in sections[section]%}
 {{ definitions[category]['name'] }}
-{{ underline * definitions[category]['underline_size'] }}
+{{ underline * definitions[category]['underline_length'] }}
 
 {% for text, values in sections[section][category].items() %}
 - {% if text %}{{ text }}{% if values %} ({{ values|join(', ') }}){% endif %}{% else %}{{ values|join(', ') }}{% endif  %}

--- a/src/towncrier/templates/hr-between-versions.rst
+++ b/src/towncrier/templates/hr-between-versions.rst
@@ -16,7 +16,7 @@
 {% if sections[section] %}
 {% for category, val in definitions.items() if category in sections[section]%}
 {{ definitions[category]['name'] }}
-{{ underline * definitions[category]['name']|length }}
+{{ underline * definitions[category]['underline_size'] }}
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}

--- a/src/towncrier/templates/hr-between-versions.rst
+++ b/src/towncrier/templates/hr-between-versions.rst
@@ -1,22 +1,22 @@
 {% if render_title %}
 {% if versiondata.name %}
 {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.version + versiondata.date)|length + 4 + versiondata_name_underline_length)}}
+{{ top_underline * (get_underline_length(versiondata.name + versiondata.version + versiondata.date) + 4)}}
 {% else %}
 {{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}
+{{ top_underline * (get_underline_length(versiondata.version + versiondata.date) + 3)}}
 {% endif %}
 {% endif %}
 {% for section, _ in sections.items() %}
 {% set underline = underlines[0] %}{% if section %}{{section}}
-{{ underline * section|length }}{% set underline = underlines[1] %}
+{{ underline * get_underline_length(section) }}{% set underline = underlines[1] %}
 
 {% endif %}
 
 {% if sections[section] %}
 {% for category, val in definitions.items() if category in sections[section]%}
 {{ definitions[category]['name'] }}
-{{ underline * definitions[category]['underline_length'] }}
+{{ underline * get_underline_length(definitions[category]['name']) }}
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}
@@ -28,7 +28,7 @@
 - {{ sections[section][category]['']|join(', ') }}
 
 {% endif %}
-{% if sections[section][category]|length == 0 %}
+{% if get_underline_length(sections[section][category]) == 0 %}
 No significant changes.
 
 {% else %}

--- a/src/towncrier/templates/hr-between-versions.rst
+++ b/src/towncrier/templates/hr-between-versions.rst
@@ -1,7 +1,7 @@
 {% if render_title %}
 {% if versiondata.name %}
 {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.name + versiondata.version + versiondata.date)|length + 4)}}
+{{ top_underline * ((versiondata.version + versiondata.date)|length + 4 + versiondata_name_underline_size)}}
 {% else %}
 {{ versiondata.version }} ({{ versiondata.date }})
 {{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}

--- a/src/towncrier/templates/hr-between-versions.rst
+++ b/src/towncrier/templates/hr-between-versions.rst
@@ -1,7 +1,7 @@
 {% if render_title %}
 {% if versiondata.name %}
 {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.version + versiondata.date)|length + 4 + versiondata_name_underline_size)}}
+{{ top_underline * ((versiondata.version + versiondata.date)|length + 4 + versiondata_name_underline_length)}}
 {% else %}
 {{ versiondata.version }} ({{ versiondata.date }})
 {{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}
@@ -16,7 +16,7 @@
 {% if sections[section] %}
 {% for category, val in definitions.items() if category in sections[section]%}
 {{ definitions[category]['name'] }}
-{{ underline * definitions[category]['underline_size'] }}
+{{ underline * definitions[category]['underline_length'] }}
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}

--- a/src/towncrier/templates/single-file-no-bullets.rst
+++ b/src/towncrier/templates/single-file-no-bullets.rst
@@ -1,7 +1,7 @@
 {% if render_title %}
 {% if versiondata.name %}
 {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.version + versiondata.date)|length + 4 + versiondata_name_underline_size)}}
+{{ top_underline * ((versiondata.version + versiondata.date)|length + 4 + versiondata_name_underline_length)}}
 {% else %}
 {{ versiondata.version }} ({{ versiondata.date }})
 {{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}
@@ -16,7 +16,7 @@
 {% for category, val in definitions.items() if category in sections[section] %}
 
 {{ definitions[category]['name'] }}
-{{ underline * definitions[category]['underline_size'] }}
+{{ underline * definitions[category]['underline_length'] }}
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}

--- a/src/towncrier/templates/single-file-no-bullets.rst
+++ b/src/towncrier/templates/single-file-no-bullets.rst
@@ -1,22 +1,22 @@
 {% if render_title %}
 {% if versiondata.name %}
 {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.version + versiondata.date)|length + 4 + versiondata_name_underline_length)}}
+{{ top_underline * (get_underline_length(versiondata.name + versiondata.version + versiondata.date) + 4)}}
 {% else %}
 {{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}
+{{ top_underline * (get_underline_length(versiondata.version + versiondata.date) + 3)}}
 {% endif %}
 {% endif %}
 {% for section, _ in sections.items() %}
 {% set underline = underlines[0] %}{% if section %}{{section}}
-{{ underline * section|length }}{% set underline = underlines[1] %}
+{{ underline * get_underline_length(section) }}{% set underline = underlines[1] %}
 
 {% endif %}
 {% if sections[section] %}
 {% for category, val in definitions.items() if category in sections[section] %}
 
 {{ definitions[category]['name'] }}
-{{ underline * definitions[category]['underline_length'] }}
+{{ underline * get_underline_length(definitions[category]['name']) }}
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}
@@ -28,7 +28,7 @@
 - {{ sections[section][category]['']|join(', ') }}
 
 {% endif %}
-{% if sections[section][category]|length == 0 %}
+{% if get_underline_length(sections[section][category]) == 0 %}
 No significant changes.
 
 {% else %}

--- a/src/towncrier/templates/single-file-no-bullets.rst
+++ b/src/towncrier/templates/single-file-no-bullets.rst
@@ -1,7 +1,7 @@
 {% if render_title %}
 {% if versiondata.name %}
 {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.name + versiondata.version + versiondata.date)|length + 4)}}
+{{ top_underline * ((versiondata.version + versiondata.date)|length + 4 + versiondata_name_underline_size)}}
 {% else %}
 {{ versiondata.version }} ({{ versiondata.date }})
 {{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}

--- a/src/towncrier/templates/single-file-no-bullets.rst
+++ b/src/towncrier/templates/single-file-no-bullets.rst
@@ -16,7 +16,7 @@
 {% for category, val in definitions.items() if category in sections[section] %}
 
 {{ definitions[category]['name'] }}
-{{ underline * definitions[category]['name']|length }}
+{{ underline * definitions[category]['underline_size'] }}
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}

--- a/src/towncrier/test/helpers.py
+++ b/src/towncrier/test/helpers.py
@@ -29,7 +29,7 @@ def write(path: str | Path, contents: str, dedent: bool = False) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
     if dedent:
         contents = textwrap.dedent(contents)
-    p.write_text(contents)
+    p.write_text(contents, encoding="utf-8")
 
 
 def read_pkg_resource(path: str) -> str:
@@ -65,9 +65,9 @@ def setup_simple_project(
         config = "[tool.towncrier]\n" 'package = "foo"\n' + extra_config
     else:
         config = textwrap.dedent(config)
-    Path(pyproject_path).write_text(config)
+    Path(pyproject_path).write_text(config, encoding="utf-8")
     Path("foo").mkdir()
-    Path("foo/__init__.py").write_text('__version__ = "1.2.3"\n')
+    Path("foo/__init__.py").write_text('__version__ = "1.2.3"\n', encoding="utf-8")
 
     if mkdir_newsfragments:
         Path("foo/newsfragments").mkdir()

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1401,6 +1401,58 @@ class TestCli(TestCase):
     @with_project(
         config="""
         [tool.towncrier]
+        name = "🍫 FooBar"
+
+          [[tool.towncrier.type]]
+          directory = "bugfix"
+          name = "🐛 Bugfixes"
+          showcontent = true
+        """
+    )
+    def test_underline_size_unicode(self, runner):
+        """
+        TODO: Add better description
+        """
+        os.mkdir("newsfragments")
+        with open("newsfragments/321.bugfix", "w") as f:
+            f.write("Squashed a bug")
+
+        result = runner.invoke(
+            _main,
+            [
+                "--version=7.8.9",
+                "--date=01-01-2001",
+                "--draft",
+            ],
+        )
+
+        expected_output = dedent(
+            """\
+            Loading template...
+            Finding news fragments...
+            Rendering news fragments...
+            Draft only -- nothing has been written.
+            What is seen below is what would be written.
+
+            🍫 FooBar 7.8.9 (01-01-2001)
+            ============================
+
+            🐛 Bugfixes
+            -----------
+
+            - Squashed a bug (#321)
+
+
+
+        """
+        )
+
+        self.assertEqual(0, result.exit_code, result.output)
+        self.assertEqual(expected_output, result.output)
+
+    @with_project(
+        config="""
+        [tool.towncrier]
         name = ""
         directory = "changes"
         filename = "NEWS.md"

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1411,7 +1411,11 @@ class TestCli(TestCase):
     )
     def test_underline_size_unicode(self, runner):
         """
-        TODO: Add better description
+        The news file can be generated for project names,
+        and categories that contains emoji in their names.
+
+        This is a test for generating the RST section
+        underline to meet the docutils requirements.
         """
         os.mkdir("newsfragments")
         with open("newsfragments/321.bugfix", "w") as f:

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1409,7 +1409,7 @@ class TestCli(TestCase):
           showcontent = true
         """
     )
-    def test_underline_size_unicode(self, runner):
+    def test_underline_length_unicode(self, runner):
         """
         The news file can be generated for project names,
         and categories that contains emoji in their names.

--- a/src/towncrier/test/test_builder.py
+++ b/src/towncrier/test/test_builder.py
@@ -41,6 +41,14 @@ class TestParseNewsfragmentBasename(TestCase):
             ("123", "feature", 1),
         )
 
+    def test_get_underline_size_ascii(self):
+        """Determine underline size for normal ASCII strings."""
+        assert get_underline_size("bugfixes") == 8
+
+    def test_get_underline_size_wide_character(self):
+        """Determine underline size for strings with wide characters."""
+        assert get_underline_size("🐛 Bugfixes") == 11
+
     def test_ignores_extension(self):
         """File extensions are ignored."""
         self.assertEqual(
@@ -208,13 +216,3 @@ class TestNewsFragmentsOrdering(TestCase):
             - Added Fish
 """
         )
-
-
-class TestUtilityFunctions(TestCase):
-    def test_get_underline_size_ascii(self):
-        """Determine underline size for normal ASCII strings."""
-        assert get_underline_size("bugfixes") == 8
-
-    def test_get_underline_size_wide_character(self):
-        """Determine underline size for strings with wide characters."""
-        assert get_underline_size("🐛 Bugfixes") == 11

--- a/src/towncrier/test/test_builder.py
+++ b/src/towncrier/test/test_builder.py
@@ -53,6 +53,26 @@ class TestParseNewsfragmentBasename(TestCase):
         """Determine underline size for strings with wide characters."""
         assert get_underline_length("🐛 Bugfixes") == 11
 
+    def test_get_underline_length_list_of_lists(self):
+        """Determine underline size for lists."""
+        assert get_underline_length([["a", "b"], ["c", "d"]]) == 4
+
+    def test_get_underline_length_dict_of_dicts(self):
+        """Determine underline size for dictionaries."""
+        assert get_underline_length({"a": {"b": "c"}, "d": {"e": "f"}}) == 6
+
+    def test_get_underline_length_int(self):
+        """Determine underline size for integers."""
+        assert get_underline_length(123) == 3
+
+    def test_get_underline_length_float(self):
+        """Determine underline size for floats."""
+        assert get_underline_length(123.5) == 5
+
+    def test_get_underline_length_wrong_type(self):
+        """Determine underline size for wrong type."""
+        self.assertRaises(TypeError, get_underline_length, None)
+
     def test_ignores_extension(self):
         """File extensions are ignored."""
         self.assertEqual(

--- a/src/towncrier/test/test_builder.py
+++ b/src/towncrier/test/test_builder.py
@@ -5,7 +5,11 @@ from textwrap import dedent
 
 from twisted.trial.unittest import TestCase
 
-from .._builder import get_underline_size, parse_newfragment_basename, render_fragments
+from .._builder import (
+    get_underline_length,
+    parse_newfragment_basename,
+    render_fragments,
+)
 
 
 class TestParseNewsfragmentBasename(TestCase):
@@ -41,13 +45,13 @@ class TestParseNewsfragmentBasename(TestCase):
             ("123", "feature", 1),
         )
 
-    def test_get_underline_size_ascii(self):
+    def test_get_underline_length_ascii(self):
         """Determine underline size for normal ASCII strings."""
-        assert get_underline_size("bugfixes") == 8
+        assert get_underline_length("bugfixes") == 8
 
-    def test_get_underline_size_wide_character(self):
+    def test_get_underline_length_wide_character(self):
         """Determine underline size for strings with wide characters."""
-        assert get_underline_size("🐛 Bugfixes") == 11
+        assert get_underline_length("🐛 Bugfixes") == 11
 
     def test_ignores_extension(self):
         """File extensions are ignored."""

--- a/src/towncrier/test/test_builder.py
+++ b/src/towncrier/test/test_builder.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 
 from twisted.trial.unittest import TestCase
 
-from .._builder import parse_newfragment_basename, render_fragments
+from .._builder import get_underline_size, parse_newfragment_basename, render_fragments
 
 
 class TestParseNewsfragmentBasename(TestCase):
@@ -208,3 +208,13 @@ class TestNewsFragmentsOrdering(TestCase):
             - Added Fish
 """
         )
+
+
+class TestUtilityFunctions(TestCase):
+    def test_get_underline_size_ascii(self):
+        """Determine underline size for normal ASCII strings."""
+        assert get_underline_size("bugfixes") == 8
+
+    def test_get_underline_size_wide_character(self):
+        """Determine underline size for strings with wide characters."""
+        assert get_underline_size("🐛 Bugfixes") == 11


### PR DESCRIPTION
# Description

Fixes #626 

<!-- add a short summary if necessary; mention issue numbers -->
Added a helper function to calculate the underline size for the jinja templates. Specifically addresses not enough underline characters being produced for category names that include wide characters like emojis.


# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [X] Make sure changes are covered by existing or new tests.
* [X] For at least one Python version, make sure test pass on your local environment.
* [X] Create a file in `src/towncrier/newsfragments/`. Briefly describe your
  changes, with information useful to end users. Your change will be included in the public release notes.
* [X] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [X] Ensure `docs/tutorial.rst` is still up-to-date.
* [X] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [X] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
