### PR TITLE
Enforce fragment name structure

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -147,6 +147,11 @@ Top level keys
     -   ``README.rst``
     -   the template file itself
 
+``fragment_filename_stem_pattern``
+    Ensure the stem (first part, excluding the category and suffix) of fragment files matches a certain regex pattern.
+    Make sure to use escape characters properly, e.g. "\\d+" for digit-only file names.
+
+    ``None`` by default.
 
 Extra top level keys for Python projects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -147,11 +147,12 @@ Top level keys
     -   ``README.rst``
     -   the template file itself
 
-``fragment_filename_stem_pattern``
-    Ensure the stem (first part, excluding the category and suffix) of fragment files matches a certain regex pattern.
-    Make sure to use escape characters properly, e.g. "\\d+" for digit-only file names.
+``issue_pattern``
+    Ensure the issue name (file name excluding the category and suffix) matches a certain regex pattern.
+    Make sure to use escape characters properly (e.g. "\\d+" for digit-only file names).
+    When emptry (``""``), all issue names will be considered valid.
 
-    ``None`` by default.
+    ``""`` by default.
 
 Extra top level keys for Python projects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -170,15 +170,15 @@ def find_fragments(
                 # Use and increment the orphan news fragment counter.
                 counter = orphan_fragment_counter[category]
                 orphan_fragment_counter[category] += 1
-            if config.fragment_filename_stem_pattern and (
+            if config.issue_pattern and (
                 not re.fullmatch(
-                    config.fragment_filename_stem_pattern,
-                    stem := Path(basename).stem.removesuffix(f".{category}"),
+                    config.issue_pattern,
+                    issue_name := Path(basename).stem.removesuffix(f".{category}"),
                 )
             ):
                 raise ClickException(
-                    f"File name stem '{stem}' does not match the "
-                    f"given pattern, '{config.fragment_filename_stem_pattern}'"
+                    f"File name '{issue_name}' does not match the "
+                    f"given issue pattern, '{config.issue_pattern}'"
                 )
             full_filename = os.path.join(section_dir, basename)
             fragment_files.append((full_filename, category))

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -172,8 +172,7 @@ def find_fragments(
                 orphan_fragment_counter[category] += 1
             if config.issue_pattern and (
                 not re.fullmatch(
-                    config.issue_pattern,
-                    issue_name := Path(basename).stem.removesuffix(f".{category}"),
+                    config.issue_pattern, issue_name := Path(basename).stem
                 )
             ):
                 raise ClickException(

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -172,11 +172,12 @@ def find_fragments(
                 orphan_fragment_counter[category] += 1
             if config.fragment_filename_stem_pattern and (
                 not re.fullmatch(
-                    config.fragment_filename_stem_pattern, stem := Path(basename).stem
+                    config.fragment_filename_stem_pattern,
+                    stem := Path(basename).stem.removesuffix(f".{category}"),
                 )
             ):
                 raise ClickException(
-                    f"File name '{stem}' does not match the "
+                    f"File name stem '{stem}' does not match the "
                     f"given pattern, '{config.fragment_filename_stem_pattern}'"
                 )
             full_filename = os.path.join(section_dir, basename)

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -170,7 +170,15 @@ def find_fragments(
                 # Use and increment the orphan news fragment counter.
                 counter = orphan_fragment_counter[category]
                 orphan_fragment_counter[category] += 1
-
+            if config.fragment_filename_stem_pattern and (
+                not re.fullmatch(
+                    config.fragment_filename_stem_pattern, stem := Path(basename).stem
+                )
+            ):
+                raise ClickException(
+                    f"File name '{stem}' does not match the "
+                    f"given pattern, '{config.fragment_filename_stem_pattern}'"
+                )
             full_filename = os.path.join(section_dir, basename)
             fragment_files.append((full_filename, category))
             data = Path(full_filename).read_text(encoding="utf-8", errors="replace")

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -55,7 +55,7 @@ class Config:
     create_eof_newline: bool = True
     create_add_extension: bool = True
     ignore: list[str] | None = None
-    fragment_filename_stem_pattern: str | None = None
+    issue_pattern: str = ""
 
 
 class ConfigError(ClickException):

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -55,6 +55,7 @@ class Config:
     create_eof_newline: bool = True
     create_add_extension: bool = True
     ignore: list[str] | None = None
+    fragment_filename_stem_pattern: str | None = None
 
 
 class ConfigError(ClickException):

--- a/src/towncrier/check.py
+++ b/src/towncrier/check.py
@@ -57,6 +57,12 @@ def _get_default_compare_branch(branches: Container[str]) -> str | None:
     metavar="FILE_PATH",
     help=config_option_help,
 )
+@click.option(
+    "--fragment-filename-pattern",
+    default=None,
+    metavar="FRAGMENT_FILE_PATTERN",
+    help=r"A regex pattern to require fragment files to match, e.g. [A-Z]+-\d+",
+)
 def _main(compare_with: str | None, directory: str | None, config: str | None) -> None:
     """
     Check for new fragments on a branch.
@@ -65,7 +71,9 @@ def _main(compare_with: str | None, directory: str | None, config: str | None) -
 
 
 def __main(
-    comparewith: str | None, directory: str | None, config_path: str | None
+    comparewith: str | None,
+    directory: str | None,
+    config_path: str | None,
 ) -> None:
     base_directory, config = load_config_from_options(directory, config_path)
 
@@ -102,7 +110,11 @@ def __main(
     click.echo("----")
 
     # This will fail if any fragment files have an invalid name:
-    all_fragment_files = find_fragments(base_directory, config, strict=True)[1]
+    all_fragment_files = find_fragments(
+        base_directory,
+        config,
+        strict=True,
+    )[1]
 
     news_file = os.path.normpath(os.path.join(base_directory, config.filename))
     if news_file in files:

--- a/src/towncrier/check.py
+++ b/src/towncrier/check.py
@@ -65,9 +65,7 @@ def _main(compare_with: str | None, directory: str | None, config: str | None) -
 
 
 def __main(
-    comparewith: str | None,
-    directory: str | None,
-    config_path: str | None,
+    comparewith: str | None, directory: str | None, config_path: str | None
 ) -> None:
     base_directory, config = load_config_from_options(directory, config_path)
 
@@ -104,11 +102,7 @@ def __main(
     click.echo("----")
 
     # This will fail if any fragment files have an invalid name:
-    all_fragment_files = find_fragments(
-        base_directory,
-        config,
-        strict=True,
-    )[1]
+    all_fragment_files = find_fragments(base_directory, config, strict=True)[1]
 
     news_file = os.path.normpath(os.path.join(base_directory, config.filename))
     if news_file in files:

--- a/src/towncrier/check.py
+++ b/src/towncrier/check.py
@@ -57,12 +57,6 @@ def _get_default_compare_branch(branches: Container[str]) -> str | None:
     metavar="FILE_PATH",
     help=config_option_help,
 )
-@click.option(
-    "--fragment-filename-pattern",
-    default=None,
-    metavar="FRAGMENT_FILE_PATTERN",
-    help=r"A regex pattern to require fragment files to match, e.g. [A-Z]+-\d+",
-)
 def _main(compare_with: str | None, directory: str | None, config: str | None) -> None:
     """
     Check for new fragments on a branch.

--- a/src/towncrier/newsfragments/649.feature.rst
+++ b/src/towncrier/newsfragments/649.feature.rst
@@ -1,0 +1,1 @@
+Add a config for enforcing the fragment filename stems, using regex.

--- a/src/towncrier/newsfragments/649.feature.rst
+++ b/src/towncrier/newsfragments/649.feature.rst
@@ -1,1 +1,1 @@
-Add a config for enforcing the fragment filename stems, using regex.
+Add a config for enforcing issue names using regex.

--- a/src/towncrier/test/test_check.py
+++ b/src/towncrier/test/test_check.py
@@ -514,3 +514,23 @@ class TestChecker(TestCase):
         result = runner.invoke(towncrier_check, ["--compare-with", "main"])
         self.assertEqual(1, result.exit_code, result.output)
         self.assertIn("Invalid news fragment name: feature.125", result.output)
+
+    # @with_isolated_runner
+    # def test_invalid_fragment_name_pattern(self, runner):
+    #     """
+    #     Fails if a news fragment has an invalid name, even if `ignore` is not set in
+    #     the config.
+    #     """
+    #     create_project(
+    #         "pyproject.toml",
+    #         extra_config=r'fragment_filename_stem_pattern = "[A-Z]+-\d+"',
+    #     )
+    #     write(
+    #         "foo/newsfragments/124.feature",
+    #         "This fragment has valid name (control case)",
+    #     )
+    #     commit("add stuff")
+
+    #     result = runner.invoke(towncrier_check, ["--compare-with", "main"])
+    #     self.assertEqual(1, result.exit_code, result.output)
+    #     self.assertIn("Invalid news fragment name: feature.125", result.output)

--- a/src/towncrier/test/test_check.py
+++ b/src/towncrier/test/test_check.py
@@ -516,34 +516,31 @@ class TestChecker(TestCase):
         self.assertIn("Invalid news fragment name: feature.125", result.output)
 
     @with_isolated_runner
-    def test_fragment_name_stem_pattern(self, runner):
+    def test_issue_pattern(self, runner):
         """
-        Fails if a news fragment has an invalid name, even if `ignore` is not set in
-        the config.
+        Fails if an issue name goes against the configured pattern.
         """
         create_project(
             "pyproject.toml",
-            extra_config='fragment_filename_stem_pattern = "\\\\d+"',
+            extra_config='issue_pattern = "\\\\d+"',
         )
         write(
-            "foo/newsfragments/AAA.feature",  #
+            "foo/newsfragments/AAA.feature",
             "This fragment has an invalid name (should be digits only)",
         )
         write(
-            "foo/newsfragments/123.feature",  #
+            "foo/newsfragments/123.feature",
             "This fragment has a valid name",
         )
         commit("add stuff")
 
         result = runner.invoke(towncrier_check, ["--compare-with", "main"])
-        print(">>>")
-        print(result)
         self.assertEqual(1, result.exit_code, result.output)
         self.assertIn(
-            "Error: File name stem 'AAA' does not match the given pattern, '\\d+'",
+            "Error: File name 'AAA' does not match the given issue pattern, '\\d+'",
             result.output,
         )
         self.assertNotIn(
-            "Error: File name stem '123' does not match the given pattern, '\\d+'",
+            "Error: File name '123' does not match the given issue pattern, '\\d+'",
             result.output,
         )

--- a/src/towncrier/test/test_check.py
+++ b/src/towncrier/test/test_check.py
@@ -525,7 +525,7 @@ class TestChecker(TestCase):
             extra_config='issue_pattern = "\\\\d+"',
         )
         write(
-            "foo/newsfragments/AAA.feature",
+            "foo/newsfragments/AAA.BBB.feature",
             "This fragment has an invalid name (should be digits only)",
         )
         write(
@@ -537,7 +537,7 @@ class TestChecker(TestCase):
         result = runner.invoke(towncrier_check, ["--compare-with", "main"])
         self.assertEqual(1, result.exit_code, result.output)
         self.assertIn(
-            "Error: File name 'AAA' does not match the given issue pattern, '\\d+'",
+            "Error: File name 'AAA.BBB' does not match the given issue pattern, '\\d+'",
             result.output,
         )
         self.assertNotIn(

--- a/src/towncrier/test/test_check.py
+++ b/src/towncrier/test/test_check.py
@@ -515,22 +515,35 @@ class TestChecker(TestCase):
         self.assertEqual(1, result.exit_code, result.output)
         self.assertIn("Invalid news fragment name: feature.125", result.output)
 
-    # @with_isolated_runner
-    # def test_invalid_fragment_name_pattern(self, runner):
-    #     """
-    #     Fails if a news fragment has an invalid name, even if `ignore` is not set in
-    #     the config.
-    #     """
-    #     create_project(
-    #         "pyproject.toml",
-    #         extra_config=r'fragment_filename_stem_pattern = "[A-Z]+-\d+"',
-    #     )
-    #     write(
-    #         "foo/newsfragments/124.feature",
-    #         "This fragment has valid name (control case)",
-    #     )
-    #     commit("add stuff")
+    @with_isolated_runner
+    def test_fragment_name_stem_pattern(self, runner):
+        """
+        Fails if a news fragment has an invalid name, even if `ignore` is not set in
+        the config.
+        """
+        create_project(
+            "pyproject.toml",
+            extra_config='fragment_filename_stem_pattern = "\\\\d+"',
+        )
+        write(
+            "foo/newsfragments/AAA.feature",  #
+            "This fragment has an invalid name (should be digits only)",
+        )
+        write(
+            "foo/newsfragments/123.feature",  #
+            "This fragment has a valid name",
+        )
+        commit("add stuff")
 
-    #     result = runner.invoke(towncrier_check, ["--compare-with", "main"])
-    #     self.assertEqual(1, result.exit_code, result.output)
-    #     self.assertIn("Invalid news fragment name: feature.125", result.output)
+        result = runner.invoke(towncrier_check, ["--compare-with", "main"])
+        print(">>>")
+        print(result)
+        self.assertEqual(1, result.exit_code, result.output)
+        self.assertIn(
+            "Error: File name stem 'AAA' does not match the given pattern, '\\d+'",
+            result.output,
+        )
+        self.assertNotIn(
+            "Error: File name stem '123' does not match the given pattern, '\\d+'",
+            result.output,
+        )


### PR DESCRIPTION
# Description

Fixes #649

Add a config for enforcing the fragment filename stems, using regex.

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure test pass on your local environment.
* [x] Create a file in `src/towncrier/newsfragments/`. Briefly describe your
  changes, with information useful to end users. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
