### PR TITLE
Improve suffix parsing in `issue_pattern`

### DIFF
--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -180,7 +180,7 @@ def find_fragments(
             if config.issue_pattern and not re.fullmatch(config.issue_pattern, issue):
                 raise ClickException(
                     f"Issue name '{issue}' does not match the "
-                    f"given issue pattern, '{config.issue_pattern}'"
+                    f"configured pattern, '{config.issue_pattern}'"
                 )
             full_filename = os.path.join(section_dir, basename)
             fragment_files.append((full_filename, category))

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -176,13 +176,10 @@ def find_fragments(
                 # Use and increment the orphan news fragment counter.
                 counter = orphan_fragment_counter[category]
                 orphan_fragment_counter[category] += 1
-            if config.issue_pattern and (
-                not re.fullmatch(
-                    config.issue_pattern, issue_name := Path(basename).stem
-                )
-            ):
+
+            if config.issue_pattern and not re.fullmatch(config.issue_pattern, issue):
                 raise ClickException(
-                    f"File name '{issue_name}' does not match the "
+                    f"Issue name '{issue}' does not match the "
                     f"given issue pattern, '{config.issue_pattern}'"
                 )
             full_filename = os.path.join(section_dir, basename)

--- a/src/towncrier/newsfragments/654.bugfix.rst
+++ b/src/towncrier/newsfragments/654.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue where `issue_template` failed recognizing the issue name of files with a non-category suffix (`.md`)

--- a/src/towncrier/test/test_check.py
+++ b/src/towncrier/test/test_check.py
@@ -530,7 +530,7 @@ class TestChecker(TestCase):
             extra_config='issue_pattern = "\\\\d+"',
         )
         write(
-            "foo/newsfragments/AAA.BBB.feature",
+            "foo/newsfragments/AAA.BBB.feature.md",
             "This fragment has an invalid name (should be digits only)",
         )
         write(
@@ -542,10 +542,14 @@ class TestChecker(TestCase):
         result = runner.invoke(towncrier_check, ["--compare-with", "main"])
         self.assertEqual(1, result.exit_code, result.output)
         self.assertIn(
-            "Error: File name 'AAA.BBB' does not match the given issue pattern, '\\d+'",
+            "Error: Issue name 'AAA.BBB' does not match the given issue pattern, '\\d+'",
             result.output,
         )
         self.assertNotIn(
-            "Error: File name '123' does not match the given issue pattern, '\\d+'",
+            "Error: Issue '123' does not match the given issue pattern, '\\d+'",
+            result.output,
+        )
+        self.assertNotIn(
+            "Error: Issue '123.feature' does not match the given issue pattern, '\\d+'",
             result.output,
         )

--- a/src/towncrier/test/test_check.py
+++ b/src/towncrier/test/test_check.py
@@ -542,14 +542,14 @@ class TestChecker(TestCase):
         result = runner.invoke(towncrier_check, ["--compare-with", "main"])
         self.assertEqual(1, result.exit_code, result.output)
         self.assertIn(
-            "Error: Issue name 'AAA.BBB' does not match the given issue pattern, '\\d+'",
+            "Error: Issue name 'AAA.BBB' does not match the configured pattern, '\\d+'",
             result.output,
         )
         self.assertNotIn(
-            "Error: Issue '123' does not match the given issue pattern, '\\d+'",
+            "Error: Issue '123' does not match the configured pattern, '\\d+'",
             result.output,
         )
         self.assertNotIn(
-            "Error: Issue '123.feature' does not match the given issue pattern, '\\d+'",
+            "Error: Issue '123.feature' does not match the configured pattern, '\\d+'",
             result.output,
         )


### PR DESCRIPTION
# Description

Fixes #653

Use internal issue name parser instead of parsing (again) the file name.

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure test pass on your local environment.
* [x] Create a file in `src/towncrier/newsfragments/`. Briefly describe your
  changes, with information useful to end users. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
