### PR TITLE
handle empty issue names

### DIFF
--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -179,7 +179,7 @@ def find_fragments(
 
             if (
                 config.issue_pattern
-                and issue  # doesn't start with +
+                and issue  # not orphan
                 and not re.fullmatch(config.issue_pattern, issue)
             ):
                 raise ClickException(

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -177,7 +177,11 @@ def find_fragments(
                 counter = orphan_fragment_counter[category]
                 orphan_fragment_counter[category] += 1
 
-            if config.issue_pattern and not re.fullmatch(config.issue_pattern, issue):
+            if (
+                config.issue_pattern
+                and issue  # doesn't start with +
+                and not re.fullmatch(config.issue_pattern, issue)
+            ):
                 raise ClickException(
                     f"Issue name '{issue}' does not match the "
                     f"configured pattern, '{config.issue_pattern}'"

--- a/src/towncrier/newsfragments/655.bugfix.rst
+++ b/src/towncrier/newsfragments/655.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed an issue where non-issue fragments (e.g. +abc1234.feature) would fail when an `issue_pattern` is configured. Non-issue fragments are now excempt from `issue_pattern` checks.
+Fixed a bug where orphan news fragments (e.g. +abc1234.feature) would fail when an `issue_pattern` is configured. Orphan news fragments are now excempt from `issue_pattern` checks.

--- a/src/towncrier/newsfragments/655.bugfix.rst
+++ b/src/towncrier/newsfragments/655.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue where non-issue fragments (e.g. +abc1234.feature) would fail when an `issue_pattern` is configured. Non-issue fragments are now excempt from `issue_pattern` checks.

--- a/src/towncrier/test/test_check.py
+++ b/src/towncrier/test/test_check.py
@@ -535,7 +535,7 @@ class TestChecker(TestCase):
         )
         write(
             "foo/newsfragments/+abcdefg.feature",
-            "This fragment has a valid name (no issue name)",
+            "This fragment has a valid name (orphan fragment)",
         )
         commit("add stuff")
 

--- a/src/towncrier/test/test_check.py
+++ b/src/towncrier/test/test_check.py
@@ -530,12 +530,30 @@ class TestChecker(TestCase):
             extra_config='issue_pattern = "\\\\d+"',
         )
         write(
-            "foo/newsfragments/AAA.BBB.feature.md",
-            "This fragment has an invalid name (should be digits only)",
-        )
-        write(
             "foo/newsfragments/123.feature",
             "This fragment has a valid name",
+        )
+        write(
+            "foo/newsfragments/+abcdefg.feature",
+            "This fragment has a valid name (no issue name)",
+        )
+        commit("add stuff")
+
+        result = runner.invoke(towncrier_check, ["--compare-with", "main"])
+        self.assertEqual(0, result.exit_code, result.output)
+
+    @with_isolated_runner
+    def test_issue_pattern_invalid_with_suffix(self, runner):
+        """
+        Fails if an issue name goes against the configured pattern.
+        """
+        create_project(
+            "pyproject.toml",
+            extra_config='issue_pattern = "\\\\d+"',
+        )
+        write(
+            "foo/newsfragments/AAA.BBB.feature.md",
+            "This fragment has an invalid name (should be digits only)",
         )
         commit("add stuff")
 
@@ -545,11 +563,25 @@ class TestChecker(TestCase):
             "Error: Issue name 'AAA.BBB' does not match the configured pattern, '\\d+'",
             result.output,
         )
-        self.assertNotIn(
-            "Error: Issue '123' does not match the configured pattern, '\\d+'",
-            result.output,
+
+    @with_isolated_runner
+    def test_issue_pattern_invalid(self, runner):
+        """
+        Fails if an issue name goes against the configured pattern.
+        """
+        create_project(
+            "pyproject.toml",
+            extra_config='issue_pattern = "\\\\d+"',
         )
-        self.assertNotIn(
-            "Error: Issue '123.feature' does not match the configured pattern, '\\d+'",
+        write(
+            "foo/newsfragments/AAA.BBB.feature",
+            "This fragment has an invalid name (should be digits only)",
+        )
+        commit("add stuff")
+
+        result = runner.invoke(towncrier_check, ["--compare-with", "main"])
+        self.assertEqual(1, result.exit_code, result.output)
+        self.assertIn(
+            "Error: Issue name 'AAA.BBB' does not match the configured pattern, '\\d+'",
             result.output,
         )


### PR DESCRIPTION
# Description

Fixes #655

allow non-issue fragments when using `issue_pattern`.

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure test pass on your local environment.
* [x] Create a file in `src/towncrier/newsfragments/`. Briefly describe your
  changes, with information useful to end users. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
