### PR TITLE
Remove a stray "c" in the docs

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -178,4 +178,4 @@ Finale
 ------
 
 You should now have everything you need to get started with ``towncrier``!
-Please see `Customizing <customization/index.html>`_ for some common c tasks, or `Configuration <configuration.html>`_ for the full configuration specification.
+Please see `Customizing <customization/index.html>`_ for some common tasks, or `Configuration <configuration.html>`_ for the full configuration specification.


### PR DESCRIPTION
# Description

Fix an apparent typo in the docs.

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [ ] Make sure changes are covered by existing or new tests.
* [ ] For at least one Python version, make sure test pass on your local environment.
* [x] Create a file in `src/towncrier/newsfragments/`. Briefly describe your
  changes, with information useful to end users. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [ ] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [ ] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
