### PR TITLE
Simple configuration for Keep a Changelog style changelogs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -288,14 +288,16 @@ If you use this way to configure custom fragment types, ensure there is no ``too
 Each table within this array has the following mandatory keys:
 
 
-``directory``
-    The type / category of the fragment.
-
-``name``
+``name`` (required)
     The description of the fragment type, as it must be included
     in the news file.
 
-``showcontent``
+``directory`` (optional)
+    The type / category of the fragment.
+
+    Defaults to ``name.lower()``.
+
+``showcontent`` (optional)
     A boolean value indicating whether the fragment contents should be included in the news file.
 
     ``true`` by default.
@@ -305,7 +307,7 @@ Each table within this array has the following mandatory keys:
         Orphan fragments (those without an issue number) always have their content included.
         If a fragment was created, it means that information is important for end users.
 
-``check``
+``check`` (optional)
     A boolean value indicating whether the fragment should be considered by the ``towncrier check`` command.
 
     ``true`` by default.
@@ -316,9 +318,7 @@ For example:
 
    [tool.towncrier]
    [[tool.towncrier.type]]
-   directory = "deprecation"
    name = "Deprecations"
-   showcontent = true
 
    [[tool.towncrier.type]]
    directory = "chore"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -292,12 +292,12 @@ Each table within this array has the following mandatory keys:
     The description of the fragment type, as it must be included
     in the news file.
 
-``directory`` (optional)
+``directory``
     The type / category of the fragment.
 
     Defaults to ``name.lower()``.
 
-``showcontent`` (optional)
+``showcontent``
     A boolean value indicating whether the fragment contents should be included in the news file.
 
     ``true`` by default.
@@ -307,7 +307,7 @@ Each table within this array has the following mandatory keys:
         Orphan fragments (those without an issue number) always have their content included.
         If a fragment was created, it means that information is important for end users.
 
-``check`` (optional)
+``check``
     A boolean value indicating whether the fragment should be considered by the ``towncrier check`` command.
 
     ``true`` by default.

--- a/docs/markdown.rst
+++ b/docs/markdown.rst
@@ -25,27 +25,21 @@ Put the following into your ``pyproject.toml`` or ``towncrier.toml``:
    issue_format = "[#{issue}](https://github.com/twisted/my-project/issues/{issue})"
 
    [[tool.towncrier.type]]
-   directory = "security"
    name = "Security"
 
    [[tool.towncrier.type]]
-   directory = "removed"
    name = "Removed"
 
    [[tool.towncrier.type]]
-   directory = "deprecated"
    name = "Deprecated"
 
    [[tool.towncrier.type]]
-   directory = "added"
    name = "Added"
 
    [[tool.towncrier.type]]
-   directory = "changed"
    name = "Changed"
 
    [[tool.towncrier.type]]
-   directory = "fixed"
    name = "Fixed"
 
 

--- a/docs/markdown.rst
+++ b/docs/markdown.rst
@@ -27,32 +27,26 @@ Put the following into your ``pyproject.toml`` or ``towncrier.toml``:
    [[tool.towncrier.type]]
    directory = "security"
    name = "Security"
-   showcontent = true
 
    [[tool.towncrier.type]]
    directory = "removed"
    name = "Removed"
-   showcontent = true
 
    [[tool.towncrier.type]]
    directory = "deprecated"
    name = "Deprecated"
-   showcontent = true
 
    [[tool.towncrier.type]]
    directory = "added"
    name = "Added"
-   showcontent = true
 
    [[tool.towncrier.type]]
    directory = "changed"
    name = "Changed"
-   showcontent = true
 
    [[tool.towncrier.type]]
    directory = "fixed"
    name = "Fixed"
-   showcontent = true
 
 
 

--- a/src/towncrier/_settings/fragment_types.py
+++ b/src/towncrier/_settings/fragment_types.py
@@ -76,8 +76,8 @@ class ArrayFragmentTypesLoader(BaseFragmentTypesLoader):
         types = {}
         types_config = self.config["type"]
         for type_config in types_config:
-            directory = type_config["directory"]
             fragment_type_name = type_config["name"]
+            directory = type_config.get("directory", fragment_type_name.lower())
             is_content_required = type_config.get("showcontent", True)
             check = type_config.get("check", True)
             types[directory] = {

--- a/src/towncrier/_settings/fragment_types.py
+++ b/src/towncrier/_settings/fragment_types.py
@@ -78,7 +78,7 @@ class ArrayFragmentTypesLoader(BaseFragmentTypesLoader):
         for type_config in types_config:
             directory = type_config["directory"]
             fragment_type_name = type_config["name"]
-            is_content_required = type_config["showcontent"]
+            is_content_required = type_config.get("showcontent", True)
             check = type_config.get("check", True)
             types[directory] = {
                 "name": fragment_type_name,

--- a/src/towncrier/newsfragments/691.feature.rst
+++ b/src/towncrier/newsfragments/691.feature.rst
@@ -1,0 +1,1 @@
+More simple configuration for Keep a Changelog style changelogs

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1776,7 +1776,7 @@ class TestCli(TestCase):
         [tool.towncrier]
         package = "foo"
         title_format = "{version} - {project_date}"
-    
+
           [[tool.towncrier.type]]
           directory = "feature"
           name = "Feature"
@@ -1795,10 +1795,10 @@ class TestCli(TestCase):
             """\
             1.0.0 - 01-01-2001
             ==================
-            
+
             Feature
             -------
-            
+
             - An exciting new feature!
             """
         )
@@ -1835,16 +1835,16 @@ class TestCli(TestCase):
             """\
             1.0.0 - 01-01-2001
             ==================
-            
+
             Feature
             -------
-            
+
             - An exciting new feature!
-            
-            
+
+
             Dependency
             ----------
-            
+
             - We bumped our dependencies.
             """
         )

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -3,6 +3,7 @@
 
 import os
 import tempfile
+import textwrap
 
 from datetime import date
 from pathlib import Path
@@ -1772,33 +1773,47 @@ class TestCli(TestCase):
 
     @with_project(
         config="""
-    [tool.towncrier]
-    title_format = "{version} - {project_date}"
-
-      [[tool.towncrier.type]]
-      directory = "feature"
-      name = "Feature"
+        [tool.towncrier]
+        package = "foo"
+        title_format = "{version} - {project_date}"
+    
+          [[tool.towncrier.type]]
+          directory = "feature"
+          name = "Feature"
+          # showcontent is not defined in TOML
     """
     )
     def test_showcontent_default_toml_array(self, runner):
         """
         When configuring custom fragment types with a TOML array
-        `showcontent` should default to `true`.
+        a missing `showcontent` defaults to `true`.
         """
-        with open("foo/newsfragments/+new_feature.feature.md", "w") as f:
-            f.write("We added an exciting new feature!")
-
-        result = runner.invoke(
-            _main, ["--draft", "--date", "01-01-2001", "--version", "1.0.0"]
+        write("foo/newsfragments/+new_feature.feature.md", "An exciting new feature!")
+        result = runner.invoke(_main, ["--date", "01-01-2001", "--version", "1.0.0"])
+        news = read("NEWS.rst")
+        expected = textwrap.dedent(
+            """\
+            1.0.0 - 01-01-2001
+            ==================
+            
+            Feature
+            -------
+            
+            - An exciting new feature!
+            """
         )
         self.assertEqual(0, result.exit_code, result.output)
+        self.assertEqual(expected, news, news)
 
     @with_project(
         config="""
         [tool.towncrier]
+        package = "foo"
         title_format = "{version} - {project_date}"
 
           [[tool.towncrier.type]]
+          # The `FRAGMENT.feature` files have no explicit
+          # `directory` configuration.
           name = "Feature"
 
           [[tool.towncrier.type]]
@@ -1809,14 +1824,29 @@ class TestCli(TestCase):
     def test_directory_default_toml_array(self, runner):
         """
         When configuring custom fragment types with a TOML array
-        the `directory` key should be optional.
+        the `directory` key is optional. Its value is inferred
+        from the `name` configuration.
         """
-        with open("foo/newsfragments/+new_feature.feature.md", "w") as f:
-            f.write("We added an exciting new feature!")
-        with open("foo/newsfragments/+bump_deps.deps.md", "w") as f:
-            f.write("We bumped our dependencies.")
-
-        result = runner.invoke(
-            _main, ["--draft", "--date", "01-01-2001", "--version", "1.0.0"]
+        write("foo/newsfragments/+new_feature.feature.md", "An exciting new feature!")
+        write("foo/newsfragments/+bump_deps.deps.md", "We bumped our dependencies.")
+        result = runner.invoke(_main, ["--date", "01-01-2001", "--version", "1.0.0"])
+        news = read("NEWS.rst")
+        expected = textwrap.dedent(
+            """\
+            1.0.0 - 01-01-2001
+            ==================
+            
+            Feature
+            -------
+            
+            - An exciting new feature!
+            
+            
+            Dependency
+            ----------
+            
+            - We bumped our dependencies.
+            """
         )
         self.assertEqual(0, result.exit_code, result.output)
+        self.assertEqual(expected, news, news)

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1769,3 +1769,26 @@ class TestCli(TestCase):
             _main, ["--draft", "--date", "01-01-2001", "--version", "1.0.0"]
         )
         self.assertEqual(0, result.exit_code, result.output)
+
+    @with_project(
+        config="""
+    [tool.towncrier]
+    title_format = "{version} - {project_date}"
+
+      [[tool.towncrier.type]]
+      directory = "feature"
+      name = "Feature"
+    """
+    )
+    def test_showcontent_default_toml_array(self, runner):
+        """
+        When configuring custom fragment types with a TOML array
+        `showcontent` should default to `true`.
+        """
+        with open("foo/newsfragments/+new_feature.feature.md", "w") as f:
+            f.write("We added an exciting new feature!")
+
+        result = runner.invoke(
+            _main, ["--draft", "--date", "01-01-2001", "--version", "1.0.0"]
+        )
+        self.assertEqual(0, result.exit_code, result.output)

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1792,3 +1792,31 @@ class TestCli(TestCase):
             _main, ["--draft", "--date", "01-01-2001", "--version", "1.0.0"]
         )
         self.assertEqual(0, result.exit_code, result.output)
+
+    @with_project(
+        config="""
+        [tool.towncrier]
+        title_format = "{version} - {project_date}"
+
+          [[tool.towncrier.type]]
+          name = "Feature"
+
+          [[tool.towncrier.type]]
+          directory = "deps"
+          name = "Dependency"
+        """
+    )
+    def test_directory_default_toml_array(self, runner):
+        """
+        When configuring custom fragment types with a TOML array
+        the `directory` key should be optional.
+        """
+        with open("foo/newsfragments/+new_feature.feature.md", "w") as f:
+            f.write("We added an exciting new feature!")
+        with open("foo/newsfragments/+bump_deps.deps.md", "w") as f:
+            f.write("We bumped our dependencies.")
+
+        result = runner.invoke(
+            _main, ["--draft", "--date", "01-01-2001", "--version", "1.0.0"]
+        )
+        self.assertEqual(0, result.exit_code, result.output)


### PR DESCRIPTION
# Description

Fixes #691 

<!-- add a short summary if necessary; mention issue numbers -->
This PR simplifies the configuration for Markdown changelog files. The `directory` key is inferred from the `name` key, and `showcontent` defaults to `true`.

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [X] Make sure changes are covered by existing or new tests.
* [X] For at least one Python version, make sure test pass on your local environment.
* [x] Create a file in `src/towncrier/newsfragments/`. Briefly describe your
  changes, with information useful to end users. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [X] Ensure `docs/tutorial.rst` is still up-to-date.
* [ ] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [ ] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
