### PR TITLE
#706 Refactor markdown template to  make it easier to read

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
+# Hint Github.com about the language use in our template files.
+# The project templates indicate the target output type (.md/.rst) rather than the template type (jinja)
+# Reference: https://github.com/github-linguist/linguist/blob/main/docs/overrides.md#using-gitattributes
 src/towncrier/templates/* linguist-language=Jinja

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/towncrier/templates/* linguist-language=Jinja

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,7 @@ source = ["src", ".nox/tests-*/**/site-packages"]
 
 [tool.coverage.report]
 show_missing = true
-skip_covered = true
+skip_covered = false
 exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING:",

--- a/src/towncrier/newsfragments/706.doc
+++ b/src/towncrier/newsfragments/706.doc
@@ -1,0 +1,1 @@
+Refactor the default markdown template to make it easier to understand, extend, and customize.

--- a/src/towncrier/templates/default.md
+++ b/src/towncrier/templates/default.md
@@ -1,58 +1,116 @@
-{% if render_title %}
-{% if versiondata.name %}
-{{header_prefix}} {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
-{% else %}
-{{header_prefix}} {{ versiondata.version }} ({{ versiondata.date }})
-{% endif %}
-{% endif %}
-{% for section, _ in sections.items() %}
-{% if section %}
+{#-
+══════════════════════════════════════════════════════════════════════════════
+TOWNCRIER MARKDOWN TEMPLATE
+══════════════════════════════════════════════════════════════════════════════
 
-{{header_prefix}}# {{section}}
-{% endif %}
+─── Macro: heading ─────────────────────────────────────────────────────────
+Purpose:
+   Generates Markdown headings with the appropriate number of # characters.
+   Based on header_prefix (default: "#") and the level argument.
 
-{% if sections[section] %}
-{% for category, val in definitions.items() if category in sections[section] %}
-{{header_prefix}}#{% if section %}#{% endif %} {{ definitions[category]['name'] }}
+Arguments:
+   level             The relative heading level (1=#, 2=##, 3=###, etc.)
+-#}
+{%- macro heading(level) -%}
+    {{- "#" * ( header_prefix | length + level -1 ) }}
+{%- endmacro -%}
 
-{% for text, values in sections[section][category].items() %}
-- {{ text }}
-{%- if values %}
-{% if "\n  - " in text or '\n  * ' in text %}
+{#-
+─── Variable: newline ──────────────────────────────────────────────────────
+Purpose:
+    Consistent newline handling. -#}
+{%- set newline = "\n" -%}
 
+{#- ════════════════════════ TEMPLATE GENERATION ════════════════════════ -#}
+{#- ─── TITLE HEADING ─── #}
+{#- render_title is false when title_format is specified in the config #}
+{%- if render_title %}
+    {%- if versiondata.name %}
+        {{- heading(1) ~ " " ~ versiondata.name ~ " " ~ versiondata.version ~ " (" ~ versiondata.date ~ ")" ~ newline }}
+    {%- else %}
+        {{- heading(1) ~ " " ~ versiondata.version ~ " (" ~ versiondata.date ~ ")" ~ newline }}
+    {%- endif %}
+{%- endif %}
+{#- If title_format is specified, we start with a new line #}
+{{- newline }}
 
-  (
-{%- else %}
-{% if text %} ({% endif %}
-{%- endif -%}
-{%- for issue in values %}
-{{ issue.split(": ", 1)[0] }}{% if not loop.last %}, {% endif %}
+{%- for section, _ in sections.items() %}
+    {#- ─── SECTION HEADING ─── #}
+    {%- if section %}
+        {{- newline }}
+        {{- heading(2) ~ " " ~ section ~ newline }}
+        {{- newline }}
+    {%- endif %}
+
+    {%- if sections[section] %}
+
+        {%- for category, val in definitions.items() if category in sections[section] %}
+            {%- set issue_pks = [] %}
+            {#- ─── CATEGORY HEADING ─── #}
+            {#- Increase heading level if section is not present #}
+            {{- heading(3 if section else 2) ~" " ~ definitions[category]['name'] ~ newline }}
+            {{- newline }}
+
+            {#- ─── RENDER ENTRIES ─── #}
+            {%- for text, values in sections[section][category].items() %}
+                {#- Prepare the string of issue numbers (e.g., "#1, #9, #142") #}
+                {%- set issue_pks = [] %}
+                {%- for v_issue in values %}
+                    {%- set _= issue_pks.append(v_issue.split(": ", 1)[0]) %}
+                {%- endfor %}
+                {%- set issues_list = issue_pks | join(", ") %}
+
+                {#- Check if text contains a sublist #}
+                {%- set text_has_sublist = (("\n  - " in text) or ("\n  * " in text)) %}
+
+                {#- CASE 1: No text, only issues #}
+                {#- Output: -  #1, #9, #142 #}
+                {%- if not text and issues_list %}
+                    {{- "- " ~ issues_list ~ newline }}
+
+                {#- Cases where both text and issues exist #}
+                {%- elif text and issues_list %}
+                    {%- if text_has_sublist %}
+                        {#- CASE 3: Text with sublist #}
+                        {#- Output: - TEXT\n\n  (#1, #9, #142) #}
+                        {{- "- " ~ text ~ newline ~ newline ~ "  (" ~ issues_list ~ ")" ~ newline }}
+                    {%- else %}
+                        {#- CASE 2: Text, no sublist #}
+                        {#- Output: - TEXT (#1, #9, #142) #}
+                        {{- "- " ~ text ~ " (" ~ issues_list ~ ")" ~ newline }}
+                    {%- endif %}
+
+                {%- elif text %}
+                    {#- Implicit Case: Text, but no issues #}
+                    {#- Output: - TEXT #}
+                    {{- "- " ~ text ~ newline }}
+                {%- endif %}
+            {%- endfor %}
+
+            {#- New line between list and link references #}
+            {{- newline }}
+
+            {#- Link references #}
+            {%- if issues_by_category[section][category] and "]: " in issues_by_category[section][category][0] %}
+                {%- for issue in issues_by_category[section][category] %}
+                    {{- issue ~ newline }}
+                {%- endfor %}
+                {{- newline }}
+            {%- endif %}
+
+            {#- No changes in this category #}
+            {%- if sections[section][category]|length == 0 %}
+                {{- newline }}
+                {{- "No significant changes." ~ newline * 2 }}
+            {%- endif %}
+        {%- endfor %}
+    {%- else %}
+        {#- No changes in this section #}
+        {{- "No significant changes." ~ newline * 2 }}
+    {%- endif %}
 {%- endfor %}
-{% if text %}){% endif %}
-
-{% else %}
-
-{% endif %}
-{% endfor %}
-
-{% if issues_by_category[section][category] and "]: " in issues_by_category[section][category][0] %}
-{% for issue in issues_by_category[section][category] %}
-{{ issue }}
-{% endfor %}
-
-{% endif %}
-{% if sections[section][category]|length == 0 %}
-No significant changes.
-
-{% else %}
-{% endif %}
-{% endfor %}
-{% else %}
-No significant changes.
-
-{% endif %}
-{% endfor +%}
-{#
-This comment adds one more newline at the end of the rendered newsfile content.
+{#-
+Newline at the end of the rendered newsfile content.
 In this way the there are 2 newlines between the latest release and the previous release content.
-#}
+-#}
+{{- newline -}}

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1135,7 +1135,7 @@ class TestCli(TestCase):
             dedent=True,
         )
 
-        result = runner.invoke(_main, ["--date", "01-01-2001"], catch_exceptions=False)
+        result = runner.invoke(_main, ["--date", "01-01-2001", "--yes"], catch_exceptions=False)
 
         with open("foo/newsfragments/123.feature", "w") as f:
             f.write("Adds levitation")
@@ -1311,7 +1311,7 @@ class TestCli(TestCase):
             dedent=True,
         )
 
-        result = runner.invoke(_main, ["--date", "01-01-2001"], catch_exceptions=False)
+        result = runner.invoke(_main, ["--date", "01-01-2001", "--yes"], catch_exceptions=False)
         self.assertEqual(0, result.exit_code, result.output)
         output = read("NEWS.rst")
 
@@ -1365,7 +1365,7 @@ class TestCli(TestCase):
             dedent=True,
         )
 
-        result = runner.invoke(_main, ["--date", "01-01-2001"], catch_exceptions=False)
+        result = runner.invoke(_main, ["--date", "01-01-2001", "--yes"], catch_exceptions=False)
         self.assertEqual(0, result.exit_code, result.output)
         output = read("NEWS.md")
 
@@ -1417,7 +1417,7 @@ class TestCli(TestCase):
             dedent=True,
         )
 
-        result = runner.invoke(_main, ["--date", "01-01-2001"], catch_exceptions=False)
+        result = runner.invoke(_main, ["--date", "01-01-2001", "--yes"], catch_exceptions=False)
         self.assertEqual(0, result.exit_code, result.output)
         output = read("NEWS.md")
 
@@ -1781,7 +1781,7 @@ class TestCli(TestCase):
         a missing `showcontent` defaults to `true`.
         """
         write("foo/newsfragments/+new_feature.feature.md", "An exciting new feature!")
-        result = runner.invoke(_main, ["--date", "01-01-2001", "--version", "1.0.0"])
+        result = runner.invoke(_main, ["--date", "01-01-2001", "--version", "1.0.0", "--yes"])
         news = read("NEWS.rst")
         expected = textwrap.dedent(
             """\
@@ -1821,7 +1821,7 @@ class TestCli(TestCase):
         """
         write("foo/newsfragments/+new_feature.feature.md", "An exciting new feature!")
         write("foo/newsfragments/+bump_deps.deps.md", "We bumped our dependencies.")
-        result = runner.invoke(_main, ["--date", "01-01-2001", "--version", "1.0.0"])
+        result = runner.invoke(_main, ["--date", "01-01-2001", "--version", "1.0.0", "--yes"])
         news = read("NEWS.rst")
         expected = textwrap.dedent(
             """\

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1135,7 +1135,9 @@ class TestCli(TestCase):
             dedent=True,
         )
 
-        result = runner.invoke(_main, ["--date", "01-01-2001", "--yes"], catch_exceptions=False)
+        result = runner.invoke(
+            _main, ["--date", "01-01-2001", "--yes"], catch_exceptions=False
+        )
 
         with open("foo/newsfragments/123.feature", "w") as f:
             f.write("Adds levitation")
@@ -1311,7 +1313,9 @@ class TestCli(TestCase):
             dedent=True,
         )
 
-        result = runner.invoke(_main, ["--date", "01-01-2001", "--yes"], catch_exceptions=False)
+        result = runner.invoke(
+            _main, ["--date", "01-01-2001", "--yes"], catch_exceptions=False
+        )
         self.assertEqual(0, result.exit_code, result.output)
         output = read("NEWS.rst")
 
@@ -1365,7 +1369,9 @@ class TestCli(TestCase):
             dedent=True,
         )
 
-        result = runner.invoke(_main, ["--date", "01-01-2001", "--yes"], catch_exceptions=False)
+        result = runner.invoke(
+            _main, ["--date", "01-01-2001", "--yes"], catch_exceptions=False
+        )
         self.assertEqual(0, result.exit_code, result.output)
         output = read("NEWS.md")
 
@@ -1417,7 +1423,9 @@ class TestCli(TestCase):
             dedent=True,
         )
 
-        result = runner.invoke(_main, ["--date", "01-01-2001", "--yes"], catch_exceptions=False)
+        result = runner.invoke(
+            _main, ["--date", "01-01-2001", "--yes"], catch_exceptions=False
+        )
         self.assertEqual(0, result.exit_code, result.output)
         output = read("NEWS.md")
 
@@ -1781,7 +1789,9 @@ class TestCli(TestCase):
         a missing `showcontent` defaults to `true`.
         """
         write("foo/newsfragments/+new_feature.feature.md", "An exciting new feature!")
-        result = runner.invoke(_main, ["--date", "01-01-2001", "--version", "1.0.0", "--yes"])
+        result = runner.invoke(
+            _main, ["--date", "01-01-2001", "--version", "1.0.0", "--yes"]
+        )
         news = read("NEWS.rst")
         expected = textwrap.dedent(
             """\
@@ -1821,7 +1831,9 @@ class TestCli(TestCase):
         """
         write("foo/newsfragments/+new_feature.feature.md", "An exciting new feature!")
         write("foo/newsfragments/+bump_deps.deps.md", "We bumped our dependencies.")
-        result = runner.invoke(_main, ["--date", "01-01-2001", "--version", "1.0.0", "--yes"])
+        result = runner.invoke(
+            _main, ["--date", "01-01-2001", "--version", "1.0.0", "--yes"]
+        )
         news = read("NEWS.rst")
         expected = textwrap.dedent(
             """\

--- a/src/towncrier/test/test_check.py
+++ b/src/towncrier/test/test_check.py
@@ -287,7 +287,12 @@ class TestChecker(TestCase):
         """
         No failure when output is piped causing None encoding for stdout.
         """
-        runner = CliRunner()
+        try:
+            runner = CliRunner(mix_stderr=False)
+        except TypeError:
+            # Fallback for older Click versions (or unexpected signature)
+            print("TypeError with mix_stderr=False, falling back to echo_stdin=True")
+            runner = CliRunner(echo_stdin=True)
 
         with runner.isolated_filesystem():
             create_project("pyproject.toml", main_branch="master")
@@ -299,7 +304,6 @@ class TestChecker(TestCase):
             check_call(["git", "add", fragment_path])
             check_call(["git", "commit", "-m", "add a newsfragment"])
 
-            runner = CliRunner(mix_stderr=False)
             result = runner.invoke(towncrier_check, ["--compare-with", "master"])
 
         self.assertEqual(0, result.exit_code)


### PR DESCRIPTION
# Description

## Template

Update the default markdown template to use standard jinja formatting

- improve logical flow
- add indentation
- add comments for easier parsing
- generally made it easier to understand, extend, and customize.

Fixes #706

## CI

- ci: add `--yes` flag to build tests to prevent interactive prompt failures
- ci: fix clirunner
  - Adapt CliRunner for different Click library versions to correctly handle error messages.
- chore: define gitattributes for templates
  - allows github to display them with the right syntax highlighting


<!-- add a short summary if necessary; mention issue numbers -->


# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure test pass on your local environment.
* [x] Create a file in `src/towncrier/newsfragments/`. Briefly describe your
  changes, with information useful to end users. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [x] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
