### PR TITLE
Update build-and-inspect-python-package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: hynek/build-and-inspect-python-package@b5076c307dc91924a82ad150cdd1533b444d3310  # v2.12.0
+    - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
 
     - name: Set up ${{ matrix.python.name }}
       uses: actions/setup-python@v4


### PR DESCRIPTION
GHA eagerly switched '3.x' to Python 3.14 and there's some incompatibilities.