### PR TITLE
Enable coverage reporting for test code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,16 +288,16 @@ jobs:
         merge-multiple: true
         path: .
 
-    - name: Combine coverage & fail if it's <100%.
+    - name: Combine coverage & check thresholds.
       run: |
         python -Im coverage combine
         python -Im coverage html --skip-covered --skip-empty
 
-        # Report and write to summary.
+        # Report full coverage (including test code) to summary.
         python -Im coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
 
-        # Report again and fail if under 100%.
-        python -Im coverage report --fail-under=100
+        # Report production code coverage and fail if under 100%.
+        python -Im coverage report --omit="src/towncrier/test/*" --fail-under=100
 
     - name: Upload HTML report if check failed.
       uses: actions/upload-artifact@v4

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,7 +46,8 @@ def coverage_report(session: nox.Session) -> None:
     session.install("coverage[toml]")
 
     session.run("coverage", "combine")
-    session.run("coverage", "report")
+    session.run("coverage", "report", "--omit=src/towncrier/test/*")
+    session.run("coverage", "report", "--include=src/towncrier/test/*")
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,5 @@ exclude_lines = [
 ]
 omit = [
     "src/towncrier/__main__.py",
-    "src/towncrier/test/*",
     "src/towncrier/click_default_group.py",
 ]


### PR DESCRIPTION
## Summary

Remove test files from the coverage omit list so that test code is included in coverage tracking. This helps detect tests that are always skipped — they would show 0% coverage.

## Changes

- **pyproject.toml**: Remove `src/towncrier/test/*` from coverage omit list
- **noxfile.py**: Update coverage_report session to show separate production and test coverage reports
- **.github/workflows/ci.yml**: CI now reports full coverage (including tests) to the step summary, while still enforcing 100% coverage for production code only
- **src/towncrier/newsfragments/711.misc**: Required changelog fragment

Fixes #711