### PR TITLE
fix: correct typos in test

### DIFF
--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -835,7 +835,7 @@ class TestCli(TestCase):
                         [
                             "[tool.towncrier]",
                             " single_file=true",
-                            " # The `filename` variable is fixed and not formated in any way.",
+                            " # The `filename` variable is fixed and not formatted in any way.",
                             ' filename="{version}-notes.rst"',
                         ]
                     )
@@ -1571,7 +1571,7 @@ class TestCli(TestCase):
     def test_uncommitted_files(self, runner, commit):
         """
         At build time, it will delete any fragment file regardless of its stage,
-        included files that are not part of the git reporsitory,
+        included files that are not part of the git repository,
         or are just staged or modified.
         """
         # 123 is committed, 124 is modified, 125 is just added, 126 is unknown


### PR DESCRIPTION
- formated → formatted
- reporsitory → repository