### PR TITLE
Allow specifying line length other than 79 when wrapping is enabled (#464)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -100,7 +100,7 @@ Top level keys
     ``["=", "-", "~"]`` by default.
 
 ``wrap``
-    Boolean value indicating whether to wrap news fragments to a line length of 79, or an integer value specifying the line length.
+    Boolean value indicating whether to wrap news fragments to a line length of 79, or an integer, greater than 0, specifying the line length.
 
     ``false`` by default.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -100,7 +100,7 @@ Top level keys
     ``["=", "-", "~"]`` by default.
 
 ``wrap``
-    Boolean value indicating whether to wrap news fragments to a line length of 79.
+    Boolean value indicating whether to wrap news fragments to a line length of 79, or an integer value specifying the line length.
 
     ``false`` by default.
 

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -441,18 +441,19 @@ def render_fragments(
     for line in res.split("\n"):
         if wrap is False:
             done.append(line)
-        else:
-            width = 79 if wrap is True else wrap
-            if width <= 0:
-                width = 79
-            done.append(
-                textwrap.fill(
-                    line,
-                    width=width,
-                    subsequent_indent=get_indent(line),
-                    break_long_words=False,
-                    break_on_hyphens=False,
-                )
+            continue
+        
+        width = 79 if wrap is True else wrap
+        if width <= 0:
+            width = 79
+        done.append(
+            textwrap.fill(
+                line,
+                width=width,
+                subsequent_indent=get_indent(line),
+                break_long_words=False,
+                break_on_hyphens=False,
             )
+        )
 
     return "\n".join(done)

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -442,7 +442,7 @@ def render_fragments(
         if wrap is False:
             done.append(line)
             continue
-        
+
         width = 79 if wrap is True else wrap
         if width <= 0:
             width = 79

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -356,7 +356,7 @@ def render_fragments(
     fragments: Mapping[str, Mapping[str, Mapping[str, Sequence[str]]]],
     definitions: Mapping[str, Mapping[str, Any]],
     underlines: Sequence[str],
-    wrap: bool,
+    wrap: bool | int,
     versiondata: Mapping[str, str],
     top_underline: str = "=",
     all_bullets: bool = False,
@@ -439,17 +439,20 @@ def render_fragments(
     )
 
     for line in res.split("\n"):
-        if wrap:
+        if wrap is False:
+            done.append(line)
+        else:
+            width = 79 if wrap is True else wrap
+            if width <= 0:
+                width = 79
             done.append(
                 textwrap.fill(
                     line,
-                    width=79,
+                    width=width,
                     subsequent_indent=get_indent(line),
                     break_long_words=False,
                     break_on_hyphens=False,
                 )
             )
-        else:
-            done.append(line)
 
     return "\n".join(done)

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -50,7 +50,7 @@ class Config:
     title_format: str | Literal[False] = ""
     issue_format: str | None = None
     underlines: Sequence[str] = ("=", "-", "~")
-    wrap: bool = False
+    wrap: bool | int = False
     all_bullets: bool = True
     orphan_prefix: str = "+"
     create_eof_newline: bool = True

--- a/src/towncrier/newsfragments/464.feature.rst
+++ b/src/towncrier/newsfragments/464.feature.rst
@@ -1,0 +1,1 @@
+Wrapped line length can now be configured by setting `wrap` to an integer value greater than 0, using 79 by default if set to `true`.

--- a/src/towncrier/test/test_format.py
+++ b/src/towncrier/test/test_format.py
@@ -414,6 +414,64 @@ Features
         )
         self.assertEqual(output, expected_output)
 
+        expected_output = """MyProject 1.0 (never)
+=====================
+
+Features
+--------
+
+- asdf asdf asdf asdf looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+  newsfragment. (#1)
+-
+  https://google.com/q=?----------------------------------------------------------------------------------------------------
+  (#2)
+- a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+  a a a a a a a a a a a a a a a a a a a a a (#3)
+
+
+"""
+
+        output = render_fragments(
+            template,
+            None,
+            fragments,
+            definitions,
+            ["-", "~"],
+            wrap=119,
+            versiondata={"name": "MyProject", "version": "1.0", "date": "never"},
+        )
+        self.assertEqual(output, expected_output)
+
+        expected_output = """MyProject 1.0 (never)
+=====================
+
+Features
+--------
+
+- asdf asdf asdf asdf
+  looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+  newsfragment. (#1)
+-
+  https://google.com/q=?----------------------------------------------------------------------------------------------------
+  (#2)
+- a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+  a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+  a a (#3)
+
+
+"""
+
+        output = render_fragments(
+            template,
+            None,
+            fragments,
+            definitions,
+            ["-", "~"],
+            wrap=0,
+            versiondata={"name": "MyProject", "version": "1.0", "date": "never"},
+        )
+        self.assertEqual(output, expected_output)
+
     def test_line_wrapping_disabled(self):
         """
         Output is not wrapped if it's disabled.


### PR DESCRIPTION
# Description

Closes #464

Config key `wrap` can now accept an integer value, enabling line wrapping and specifying what column to wrap at. `true` wraps at 79 for backwards compatibility, if it's <=0 it defaults to 79, otherwise it uses the given value.

# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [X] Make sure changes are covered by existing or new tests.
* [X] For at least one Python version, make sure test pass on your local environment.
* [X] Create a file in `src/towncrier/newsfragments/`. Briefly describe your
  changes, with information useful to end users. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [X] Ensure `docs/tutorial.rst` is still up-to-date.
* [X] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [X] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
