### PR TITLE
#668 Honor explicit underlines for markdown title_format

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -81,8 +81,9 @@ Top level keys
 
     When using reStructuredText, formatted titles are underlined using the ``underlines`` configuration.
     For titles, the first value from ``underlines`` is used to create the underline (which is inserted on the line following the title).
-    If the template has an ``.md`` suffix, we assume we are looking at markdown format and the title is applied as, i.e. full control over the title format is given to the user.
+    If the template has an ``.md`` suffix, we assume we are looking at markdown format and the title is applied as given, i.e. full control over the title format is given to the user.
     The top header level is inferred from this, e.g. ``title_format = "(v{version})=\n### {version}"`` will render the title at level 3, categories at level 4, and so on.
+    If ``underlines`` is set explicitly and the formatted title is not an ATX heading (it does not start with ``#``), the first underline character is also applied to markdown titles so setext-style headings work.
 
 ``issue_format``
     A format string for rendering the issue/ticket number in newsfiles.
@@ -95,7 +96,9 @@ Top level keys
 ``underlines``
     The characters used for underlining headers.
 
-    Not used in the bundled Markdown template.
+    Not used in the bundled Markdown template for section headings.
+    When set explicitly, the first value is also used to underline a
+    markdown ``title_format`` that is not already an ATX heading.
 
     ``["=", "-", "~"]`` by default.
 

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -50,6 +50,9 @@ class Config:
     title_format: str | Literal[False] = ""
     issue_format: str | None = None
     underlines: Sequence[str] = ("=", "-", "~")
+    # True when the user set ``underlines`` in config (so markdown titles
+    # can honor an explicit setext underline without changing the default).
+    underlines_configured: bool = False
     wrap: bool = False
     all_bullets: bool = True
     orphan_prefix: str = "+"
@@ -234,6 +237,7 @@ def parse_toml(base_path: str, config: Mapping[str, Any]) -> Config:
             )
 
     parsed_data["template"] = template
+    parsed_data["underlines_configured"] = "underlines" in config
 
     # Process 'start_string'.
 

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -243,10 +243,20 @@ def __main(
         top_line = config.title_format.format(
             name=project_name, version=project_version, project_date=project_date
         )
+        parts = [top_line]
+        underline = config.underlines[0] if config.underlines else ""
         if is_markdown:
-            parts = [top_line]
+            # Default markdown titles stay as written (ATX / custom text).
+            # An explicit ``underlines`` config is honored for setext-style
+            # titles such as ``1.0.0 (2024-09-03)`` / ``------------------``.
+            if (
+                config.underlines_configured
+                and underline
+                and not top_line.lstrip().startswith("#")
+            ):
+                parts.append(underline * len(top_line))
         else:
-            parts = [top_line, config.underlines[0] * len(top_line)]
+            parts.append(underline * len(top_line))
         parts.append(rendered)
         content = "\n".join(parts)
     else:

--- a/src/towncrier/newsfragments/668.bugfix
+++ b/src/towncrier/newsfragments/668.bugfix
@@ -1,0 +1,1 @@
+Markdown `title_format` now honors an explicit `underlines` setting for setext-style headings.

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1070,6 +1070,56 @@ class TestCli(TestCase):
         config="""
         [tool.towncrier]
         package = "foo"
+        filename = "CHANGELOG.md"
+        underlines = ["-", "", ""]
+        title_format = "{version} ({project_date})"
+        """
+    )
+    def test_title_format_markdown_setext_underlines(self, runner):
+        """
+        An explicit ``underlines`` config is honored for markdown titles
+        that are not ATX headings (setext-style Keep a Changelog headers).
+        """
+        with open("foo/newsfragments/123.feature", "w") as f:
+            f.write("Adds levitation")
+        result = runner.invoke(
+            _main,
+            [
+                "--name",
+                "FooBarBaz",
+                "--version",
+                "1.0.0",
+                "--date",
+                "2024-09-03",
+                "--draft",
+            ],
+        )
+
+        expected_output = dedent("""\
+            Loading template...
+            Finding news fragments...
+            Rendering news fragments...
+            Draft only -- nothing has been written.
+            What is seen below is what would be written.
+
+            1.0.0 (2024-09-03)
+            ------------------
+
+            # Features
+
+            - Adds levitation (#123)
+
+
+
+        """)
+
+        self.assertEqual(0, result.exit_code, result.output)
+        self.assertEqual(expected_output, result.output)
+
+    @with_project(
+        config="""
+        [tool.towncrier]
+        package = "foo"
         filename = "NEWS.md"
         title_format = "### [{project_date}] CUSTOM RELEASE for {name} version {version}"
         """

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -56,6 +56,7 @@ class TomlSettingsTests(TestCase):
         self.assertEqual(config.package_dir, ".")
         self.assertEqual(config.filename, "NEWS.rst")
         self.assertEqual(config.underlines, ("=", "-", "~"))
+        self.assertFalse(config.underlines_configured)
         self.assertEqual(config.orphan_prefix, "~")
 
     def test_markdown(self):
@@ -76,6 +77,23 @@ class TomlSettingsTests(TestCase):
         self.assertEqual(config.filename, "NEWS.md")
 
         self.assertEqual(config.template, ("towncrier.templates", "default.md"))
+
+    def test_underlines_configured(self):
+        """
+        ``underlines_configured`` is true only when the user set underlines.
+        """
+        project_dir = self.mktemp_project(
+            pyproject_toml="""
+                [tool.towncrier]
+                package = "foobar"
+                filename = "NEWS.md"
+                underlines = ["-", "", ""]
+            """
+        )
+        config = load_config(project_dir)
+        self.assertEqual(list(config.underlines), ["-", "", ""])
+        self.assertTrue(config.underlines_configured)
+
 
     def test_explicit_template_extension(self):
         """

--- a/src/towncrier/test/test_settings.py
+++ b/src/towncrier/test/test_settings.py
@@ -94,7 +94,6 @@ class TomlSettingsTests(TestCase):
         self.assertEqual(list(config.underlines), ["-", "", ""])
         self.assertTrue(config.underlines_configured)
 
-
     def test_explicit_template_extension(self):
         """
         If the filename references an .md file and the builtin template has an


### PR DESCRIPTION
## Description

`title_format` on a markdown news file never applied `underlines[0]`, so this config from #668 could not produce a setext heading:

```toml
filename = "CHANGELOG.md"
underlines = ["-", "", ""]
title_format = "{version} ({project_date})"
```

Default markdown titles are unchanged (ATX / custom text, including the Keep a Changelog example). An explicit `underlines` setting is used only when the formatted title is not already an ATX heading.

Fixes #668

## Checklist

- [x] Tests for the change
- [x] News fragment in `src/towncrier/newsfragments/`
- [x] Docs update in `docs/configuration.rst`

## Test plan

- [x] `trial towncrier.test.test_build towncrier.test.test_write towncrier.test.test_format towncrier.test.test_settings`
- [x] New test: markdown + explicit `underlines = ["-", "", ""]` + `{version} ({project_date})` renders the dash underline
- [x] Existing `test_title_format_custom_markdown` still has no default `=======` underline