### PR TITLE
#733 Reject extra dots in towncrier create fragment names

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -76,6 +76,8 @@ Create a news fragment in the directory that ``towncrier`` is configured to look
 If you don't provide a file name, ``towncrier`` will prompt you for one.
 
 ``towncrier create`` will enforce that the passed type (e.g. ``bugfix``) is valid.
+The issue identifier (the part before the type) must not contain ``.``,
+because dots separate ``{name}.{type}`` and an optional counter or suffix.
 
 If the fragments directory does not exist, it will be created.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -90,7 +90,6 @@ The five default types are:
 - ``misc``: An issue has been closed, but it is not of interest to users.
 
 When you create a news fragment, the filename consists of the issue/ticket ID (or some other unique identifier) as well as the 'type'.
-The identifier itself must not contain ``.``; dots separate the identifier from the type (and an optional counter or suffix).
 ``towncrier`` does not care about the fragment's suffix.
 
 You can create those fragments either by hand, or using the ``towncrier create`` command.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -90,6 +90,7 @@ The five default types are:
 - ``misc``: An issue has been closed, but it is not of interest to users.
 
 When you create a news fragment, the filename consists of the issue/ticket ID (or some other unique identifier) as well as the 'type'.
+The identifier itself must not contain ``.``; dots separate the identifier from the type (and an optional counter or suffix).
 ``towncrier`` does not care about the fragment's suffix.
 
 You can create those fragments either by hand, or using the ``towncrier create`` command.

--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 import os
 
+from collections.abc import Iterable
 from pathlib import Path
 from typing import cast
 
 import click
 
-from ._builder import FragmentsPath
+from ._builder import FragmentsPath, parse_newfragment_basename
 from ._settings import config_option_help, load_config_from_options
 
 
@@ -187,15 +188,7 @@ def __main(
             ),
         )
     filename_parts = filename.split(".")
-    if len(filename_parts) < 2 or (
-        filename_parts[-1] not in config.types
-        and filename_parts[-2] not in config.types
-    ):
-        raise click.BadParameter(
-            "Expected filename '{}' to be of format '{{name}}.{{type}}', "
-            "where '{{name}}' is an arbitrary slug and '{{type}}' is "
-            "one of: {}".format(filename, ", ".join(config.types))
-        )
+    _validate_create_filename(filename, config.types)
 
     if filename_parts[-1] in config.types and filename_ext:
         filename += filename_ext
@@ -240,6 +233,31 @@ def __main(
     Path(segment_file).write_text(content + "\n" * add_newline, encoding="utf-8")
 
     click.echo(f"Created news fragment at {segment_file}")
+
+
+def _validate_create_filename(filename: str, types: Iterable[str]) -> None:
+    """Reject fragment names that ``build`` cannot parse, or that hide extra dots.
+
+    ``towncrier create`` previously only checked that the last or second-to-last
+    component was a known type. That accepted names such as
+    ``foo.bar.baz.config`` (when ``config`` is a type), which ``build`` then
+    treats as issue ``foo.bar.baz``. The issue identifier must not contain
+    ``.`` because dots separate ``{name}.{type}`` (and an optional counter or
+    suffix).
+    """
+    basename = os.path.basename(filename)
+    issue, category, _counter = parse_newfragment_basename(basename, types)
+    if category is None:
+        raise click.BadParameter(
+            "Expected filename '{}' to be of format '{{name}}.{{type}}', "
+            "where '{{name}}' is an arbitrary slug and '{{type}}' is "
+            "one of: {}".format(filename, ", ".join(types))
+        )
+    if "." in issue:
+        raise click.BadParameter(
+            f"Issue identifier '{issue}' in '{filename}' must not contain '.'. "
+            "Dots separate '{name}.{type}' (and an optional counter or suffix)."
+        )
 
 
 def _get_news_content_from_user(message: str, extension: str = "") -> str:

--- a/src/towncrier/create.py
+++ b/src/towncrier/create.py
@@ -247,7 +247,7 @@ def _validate_create_filename(filename: str, types: Iterable[str]) -> None:
     """
     basename = os.path.basename(filename)
     issue, category, _counter = parse_newfragment_basename(basename, types)
-    if category is None:
+    if category is None or issue is None:
         raise click.BadParameter(
             "Expected filename '{}' to be of format '{{name}}.{{type}}', "
             "where '{{name}}' is an arbitrary slug and '{{type}}' is "

--- a/src/towncrier/newsfragments/733.bugfix.rst
+++ b/src/towncrier/newsfragments/733.bugfix.rst
@@ -1,0 +1,1 @@
+``towncrier create`` now rejects fragment names whose issue identifier contains ``.``.

--- a/src/towncrier/test/test_create.py
+++ b/src/towncrier/test/test_create.py
@@ -217,6 +217,46 @@ class TestCli(TestCase):
             "Expected filename '123.foobar.rst' to be of format", result.output
         )
 
+    def test_dots_in_issue_identifier_rejected(self):
+        """
+        Extra dots in the issue identifier are rejected.
+
+        ``create`` used to accept ``foo.bar.baz.feature`` because the last
+        component was a known type. ``build`` then treated the whole prefix
+        as the issue name, which is not a valid ``{name}.{type}``.
+        """
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            setup_simple_project()
+            result = runner.invoke(_main, ["foo.bar.baz.feature"])
+
+            self.assertEqual([], os.listdir("foo/newsfragments"))
+
+        self.assertEqual(type(result.exception), SystemExit, result.exception)
+        self.assertIn("must not contain '.'", result.output)
+        self.assertIn("foo.bar.baz", result.output)
+
+    def test_type_not_in_last_two_parts_rejected(self):
+        """
+        A type that is only the first component is not a valid create name.
+
+        ``feature.notatype`` used to pass because the second-to-last part was
+        a known type, but ``build`` cannot parse that basename.
+        """
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            setup_simple_project()
+            result = runner.invoke(_main, ["feature.notatype"])
+
+            self.assertEqual([], os.listdir("foo/newsfragments"))
+
+        self.assertEqual(type(result.exception), SystemExit, result.exception)
+        self.assertIn(
+            "Expected filename 'feature.notatype' to be of format", result.output
+        )
+
     @with_isolated_runner
     def test_custom_extension(self, runner: CliRunner):
         """Ensure we can still create fragments with custom extensions."""


### PR DESCRIPTION
## Description

`towncrier create` only checked that the last or second-to-last filename component was a known type. That accepted names such as `foo.bar.baz.feature` (or `foo.bar.baz.config` when `config` is a configured type). `build` then treated the whole dotted prefix as the issue identifier.

`create` now uses the same basename parser as `build`, and rejects an issue identifier that itself contains `.`. Dots only separate `{name}.{type}` and an optional counter or suffix.

Fixes #733

## Checklist

* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure test pass on your local environment.
* [x] Create a file in `src/towncrier/newsfragments/`. Briefly describe your changes, with information useful to end users. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [ ] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.

## Test plan

- [x] `trial towncrier.test.test_create towncrier.test.test_builder` (49 tests, all pass)
- [x] New: `foo.bar.baz.feature` is rejected
- [x] New: `feature.notatype` is rejected (build cannot parse it)
- [x] Existing valid names (`123.feature`, `123.feature.rst`, `123.feature.1`, orphans) still work