### PR TITLE
#556 ignore backup fragments ending in ~

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -140,7 +140,7 @@ Top level keys
 
     ``towncrier check`` will fail if there are any news fragment files that have invalid filenames, except for those in the list. ``towncrier build`` will likewise fail, but only if this list has been configured (set to an empty list if there are no files to ignore).
 
-    The following filenames are automatically ignored, case insensitive.
+    The following filenames and patterns are automatically ignored, case insensitive.
 
     -   ``.gitignore``
     -   ``.gitkeep``
@@ -148,6 +148,7 @@ Top level keys
     -   ``README``
     -   ``README.md``
     -   ``README.rst``
+    -   ``*~``
     -   the template file itself
 
 ``issue_pattern``

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -123,6 +123,7 @@ def find_fragments(
         "readme",
         "readme.md",
         "readme.rst",
+        "*~",
     }
     if isinstance(config.template, str):
         # Template can be a tuple of (package_name, resource_name).

--- a/src/towncrier/newsfragments/556.bugfix
+++ b/src/towncrier/newsfragments/556.bugfix
@@ -1,0 +1,1 @@
+Files ending in ~ are now ignored when searching for newsfragments.

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -1704,6 +1704,32 @@ class TestCli(TestCase):
         ignore = []
         """
     )
+    def test_ignore_backup_files(self, runner):
+        """
+        When a file ends with `~` it must be ignored.
+        """
+        with open("foo/newsfragments/123.feature", "w") as f:
+            f.write("This has a valid filename (control case)")
+        with open("foo/newsfragments/001.feature~", "w") as f:
+            f.write("This file must be ignored")
+        with open("foo/newsfragments/002.feature.rst~", "w") as f:
+            f.write("Even if it has an extension it must be equally ignored")
+
+        result = runner.invoke(_main, ["--draft"])
+        self.assertEqual(0, result.exit_code, result.output)
+        self.assertIn("This has a valid filename (control case)", result.output)
+        self.assertNotIn("This file must be ignored", result.output)
+        self.assertNotIn(
+            "Even if it has an extension it must be equally ignored", result.output
+        )
+
+    @with_project(
+        config="""
+        [tool.towncrier]
+        package = "foo"
+        ignore = []
+        """
+    )
     def test_invalid_fragment_name(self, runner):
         """
         When `ignore` is set in config, invalid filenames cause failure.


### PR DESCRIPTION
# Description

Fixes #556 

Files ending in ~ are ignored using the existing ignore mechanism. 

This is tested by `test_ignore_backup_files`, which tests `feature~` and `feature.rst~` 

`docs/configuration.rst` has been minimally updated to reflect this change and the corresponding fragment (`556.bugfix`) has been created. 

Checks: `pre_commit`, `check_newsfragment` and the full suite.

# Checklist

* [x] Make sure changes are covered by existing or new tests.
* [x] For at least one Python version, make sure tests pass on your local environment.
* [x] Create a file in `src/towncrier/newsfragments/`. Briefly describe your changes, with information useful to end users. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [x] Ensure `docs/tutorial.rst` is still up-to-date.
* [x] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [x] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.