### PR TITLE
#747 Add codespell to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
             run: nox -e typecheck
             run-if: true
 
-          - name: Check spelling errors
+          - name: Check spelling
             run: nox -e codespell
             run-if: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,10 @@ jobs:
             run: nox -e typecheck
             run-if: true
 
+          - name: Check spelling errors
+            run: nox -e codespell
+            run-if: true
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -196,7 +200,7 @@ jobs:
     - name: Check
       run: |
         ${{ matrix.task.run }}
-      if: ${{ matrix.task.run-if }}
+      if: ${{ !cancelled() && matrix.task.run-if }}
 
 
   pre-commit:

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -74,7 +74,7 @@ Bugfixes
 - The template file is now ignored based only on the file name. (`#638 <https://github.com/twisted/towncrier/issues/638>`_)
 - Control of the header formatting is once again completely up to the user when they are writing markdown files (fixes a regression introduced in [#610](https://github.com/twisted/towncrier/pull/610)). (`#651 <https://github.com/twisted/towncrier/issues/651>`_)
 - Fixed an issue where `issue_template` failed recognizing the issue name of files with a non-category suffix (`.md`) (`#654 <https://github.com/twisted/towncrier/issues/654>`_)
-- Fixed a bug where orphan news fragments (e.g. +abc1234.feature) would fail when an `issue_pattern` is configured. Orphan news fragments are now excempt from `issue_pattern` checks. (`#655 <https://github.com/twisted/towncrier/issues/655>`_)
+- Fixed a bug where orphan news fragments (e.g. +abc1234.feature) would fail when an `issue_pattern` is configured. Orphan news fragments are now exempt from `issue_pattern` checks. (`#655 <https://github.com/twisted/towncrier/issues/655>`_)
 
 
 Deprecations and Removals
@@ -501,7 +501,7 @@ towncrier 19.2.0 (2019-02-15)
 Features
 --------
 
-- Add support for multiple fragements per issue/type pair. This extends the
+- Add support for multiple fragments per issue/type pair. This extends the
   naming pattern of the fragments to `issuenumber.type(.counter)` where counter
   is an optional integer. (`#119 <https://github.com/twisted/towncrier/issues/119>`_)
 - Python 2.7 is now supported. (`#121 <https://github.com/twisted/towncrier/issues/121>`_)
@@ -621,7 +621,7 @@ Bugfixes
 Features
 --------
 
-- Allow configration of the template file, title text and "magic comment" (#35)
+- Allow configuration of the template file, title text and "magic comment" (#35)
 - Towncrier now uses pyproject.toml, as defined in PEP-518. (#40)
 
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -153,7 +153,7 @@ Top level keys
 ``issue_pattern``
     Ensure the issue name (file name excluding the category and suffix) matches a certain regex pattern.
     Make sure to use escape characters properly (e.g. "\\d+" for digit-only file names).
-    When emptry (``""``), all issue names will be considered valid.
+    When empty (``""``), all issue names will be considered valid.
 
     ``""`` by default.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -70,6 +70,12 @@ def typecheck(session: nox.Session) -> None:
 
 
 @nox.session
+def codespell(session: nox.Session) -> None:
+    session.install(".", "codespell")
+    session.run("codespell")
+
+
+@nox.session
 def docs(session: nox.Session) -> None:
     session.install(".[dev]")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "furo >= 2024.05.06",
     "twisted",
     "nox",
+    "codespell >= 2.4"
 ]
 
 [project.scripts]
@@ -162,3 +163,9 @@ omit = [
     "src/towncrier/test/*",
     "src/towncrier/click_default_group.py",
 ]
+
+[tool.codespell]
+skip = 'venv*, .venv*, .nox*, .git*, dist*'
+count = false
+quiet-level = 3
+check-hidden = true

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -112,7 +112,7 @@ def find_fragments(
     strict: bool,
 ) -> tuple[Mapping[str, Mapping[tuple[str, str, int], str]], list[tuple[str, str]]]:
     """
-    Sections are a dictonary of section names to paths.
+    Sections are a dictionary of section names to paths.
 
     If strict, raise ClickException if any fragments have an invalid name.
     """

--- a/src/towncrier/_shell.py
+++ b/src/towncrier/_shell.py
@@ -4,7 +4,7 @@
 """
 Entry point of the command line interface.
 
-Each sub-command has its separate CLI definition andd help messages.
+Each sub-command has its separate CLI definition and help messages.
 """
 
 from __future__ import annotations

--- a/src/towncrier/test/test_build.py
+++ b/src/towncrier/test/test_build.py
@@ -835,7 +835,7 @@ class TestCli(TestCase):
                         [
                             "[tool.towncrier]",
                             " single_file=true",
-                            " # The `filename` variable is fixed and not formated in any way.",
+                            " # The `filename` variable is fixed and not formatted in any way.",
                             ' filename="{version}-notes.rst"',
                         ]
                     )
@@ -1571,7 +1571,7 @@ class TestCli(TestCase):
     def test_uncommitted_files(self, runner, commit):
         """
         At build time, it will delete any fragment file regardless of its stage,
-        included files that are not part of the git reporsitory,
+        included files that are not part of the git repository,
         or are just staged or modified.
         """
         # 123 is committed, 124 is modified, 125 is just added, 126 is unknown

--- a/src/towncrier/test/test_format.py
+++ b/src/towncrier/test/test_format.py
@@ -173,7 +173,7 @@ Bugfixes
 
     def test_markdown(self):
         """
-        Check formating of default markdown template.
+        Check formatting of default markdown template.
         """
         fragments = {
             "": {

--- a/src/towncrier/test/test_novcs.py
+++ b/src/towncrier/test/test_novcs.py
@@ -6,7 +6,7 @@ from towncrier import _novcs
 class TestNOVCS(TestCase):
     def test_get_default_compare_branch(self):
         """
-        Witout a version control system, there is no default branch.
+        Without a version control system, there is no default branch.
         """
         self.assertEqual(None, _novcs.get_default_compare_branch([]))
 


### PR DESCRIPTION
# Description

Fixes #747

Add a small helper to check for typos.


# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [NA] Make sure changes are covered by existing or new tests.
* [NA] For at least one Python version, make sure test pass on your local environment.
* [x] Create a file in `src/towncrier/newsfragments/`. Briefly describe your
  changes, with information useful to end users. Your change will be included in the public release notes.
* [x] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [NA] Ensure `docs/tutorial.rst` is still up-to-date.
* [NA] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [NA] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
